### PR TITLE
fix: sync session lifespan watches directly to hardware key constraints

### DIFF
--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -11,6 +11,7 @@ interface SessionPayload {
 }
 
 const SESSION_KEY = "utility-session";
+const WALLET_SESSION_KEY = "utility-wallet-session";
 const REFRESH_INTERVAL = 60_000;
 
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
@@ -113,13 +114,24 @@ function stopRefreshTimer() {
   }
 }
 
+function isWalletConnected(address: string): boolean {
+  try {
+    const raw = localStorage.getItem(WALLET_SESSION_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw);
+    return parsed.address === address;
+  } catch {
+    return false;
+  }
+}
+
 export function monitorWalletLock(
   address: string,
   onLocked: () => void
 ): () => void {
   const interval = setInterval(() => {
-    const session = getSession();
-    if (!session || session.address !== address) {
+    if (!isWalletConnected(address)) {
+      destroySession();
       onLocked();
       clearInterval(interval);
     }


### PR DESCRIPTION
## Problem

When a user locks or disconnects their browser-based wallet, the backend API session remains active. \monitorWalletLock\ was polling the session storage (\utility-session\) rather than the actual wallet connection state. A malicious actor with access to the unattended machine could continue performing authenticated actions until the session timer expired.

## Solution

Added \isWalletConnected(address)\ helper that reads the actual wallet connection state from \utility-wallet-session\ (the key used by \WalletProvider\). Updated \monitorWalletLock\ to poll wallet existence via this helper and call \destroySession()\ immediately when the wallet is gone.

## Changes

- \src/services/session.ts\: Added \WALLET_SESSION_KEY\ constant and \isWalletConnected()\ helper
- \monitorWalletLock()\ now checks actual wallet state instead of session state
- Session is destroyed synchronously with \onLocked()\ callback when wallet disconnects

Closes #22