### PR TITLE
feat: add cache-purge pipeline on account switch

### DIFF
--- a/src/components/providers/WalletProvider.tsx
+++ b/src/components/providers/WalletProvider.tsx
@@ -9,6 +9,8 @@ import {
   useRef,
 } from "react";
 import { Keypair } from "@stellar/stellar-sdk";
+import { abortAllRequests } from "@/services/api";
+import { cacheClearByPrefix } from "@/services/cache";
 
 export interface WalletAccount {
   address: string;
@@ -21,10 +23,11 @@ interface WalletContextValue {
   isConnected: boolean;
   isConnecting: boolean;
   accounts: WalletAccount[];
+  cacheVersion: number;
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
   switchAccount: (address: string) => Promise<void>;
-  purgeCache: () => void;
+  purgeCache: (oldAddress?: string) => Promise<void>;
 }
 
 const WalletContext = createContext<WalletContextValue>({
@@ -32,10 +35,11 @@ const WalletContext = createContext<WalletContextValue>({
   isConnected: false,
   isConnecting: false,
   accounts: [],
+  cacheVersion: 0,
   connect: async () => {},
   disconnect: async () => {},
   switchAccount: async () => {},
-  purgeCache: () => {},
+  purgeCache: async () => {},
 });
 
 let switchGuard = Promise.resolve();
@@ -46,10 +50,21 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [isConnecting, setIsConnecting] = useState(false);
   const cacheVersion = useRef(0);
 
-  const purgeCache = useCallback(() => {
+  const purgeCache = useCallback(async (oldAddress?: string) => {
     cacheVersion.current += 1;
+
+    setAccount(null);
+    setAccounts([]);
+
     localStorage.removeItem("utility-wallet-session");
     localStorage.removeItem("utility-wallet-accounts");
+    localStorage.removeItem("utility-auth-session");
+
+    abortAllRequests();
+
+    if (oldAddress) {
+      await cacheClearByPrefix(`utility:${oldAddress}`);
+    }
   }, []);
 
   const connect = useCallback(async () => {
@@ -76,18 +91,18 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   }, [isConnecting]);
 
   const disconnect = useCallback(async () => {
-    purgeCache();
-    setAccount(null);
-    setAccounts([]);
-  }, [purgeCache]);
+    await purgeCache(account?.address);
+  }, [purgeCache, account]);
 
   const switchAccount = useCallback(
     async (address: string) => {
       switchGuard = switchGuard.then(async () => {
         const target = accounts.find((a) => a.address === address);
         if (!target) return;
-        setAccount(null);
-        await new Promise((r) => setTimeout(r, 0));
+
+        const oldAddress = account?.address;
+        await purgeCache(oldAddress);
+
         setAccount(target);
         localStorage.setItem(
           "utility-wallet-session",
@@ -96,7 +111,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       });
       await switchGuard;
     },
-    [accounts]
+    [accounts, account, purgeCache]
   );
 
   useEffect(() => {
@@ -123,6 +138,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
         isConnected: !!account,
         isConnecting,
         accounts,
+        cacheVersion: cacheVersion.current,
         connect,
         disconnect,
         switchAccount,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -23,6 +23,7 @@ const defaultConfig: ApiConfig = {
 };
 
 let sessionToken: string | null = null;
+const activeControllers = new Set<AbortController>();
 
 export function setSessionToken(token: string | null) {
   sessionToken = token;
@@ -30,6 +31,13 @@ export function setSessionToken(token: string | null) {
 
 export function getSessionToken(): string | null {
   return sessionToken;
+}
+
+export function abortAllRequests(): void {
+  for (const ctrl of activeControllers) {
+    ctrl.abort();
+  }
+  activeControllers.clear();
 }
 
 async function request<T>(
@@ -41,6 +49,7 @@ async function request<T>(
   const cfg = { ...defaultConfig, ...config };
   const url = `${cfg.baseUrl}${path}`;
   const controller = new AbortController();
+  activeControllers.add(controller);
   const timeoutId = setTimeout(() => controller.abort(), cfg.timeout);
 
   try {
@@ -83,6 +92,8 @@ async function request<T>(
       error: (err as Error).message || "Network error",
       status: 0,
     };
+  } finally {
+    activeControllers.delete(controller);
   }
 }
 

--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -103,6 +103,22 @@ export async function cacheClear(): Promise<void> {
   }
 }
 
+export async function cacheClearByPrefix(prefix: string): Promise<void> {
+  try {
+    const db = await getDb();
+    const keys = await db.getAllKeys("kv");
+    const tx = db.transaction("kv", "readwrite");
+    for (const key of keys) {
+      if (String(key).startsWith(prefix)) {
+        tx.store.delete(key);
+      }
+    }
+    await tx.done;
+  } catch {
+    // silently fail
+  }
+}
+
 export async function cacheKeys(prefix?: string): Promise<string[]> {
   try {
     const db = await getDb();


### PR DESCRIPTION
## Scope

Fixes stale contract state and cached RPC responses persisting when users switch between multiple Stellar accounts.

## Changes

### WalletProvider (\src/components/providers/WalletProvider.tsx\)
- **cacheVersion ref** exposed via \WalletContext\ — descendant hooks can observe it before resolving stale promises
- **purgeCache() pipeline** atomically clears React context state (\ccount\, \ccounts\), localStorage entries (\utility-wallet-session\, \utility-wallet-accounts\, \utility-auth-session\), IndexedDB stores scoped to the old account key prefix, and aborts in-flight RPC requests
- **switchAccount guard** serializes execution via a module-level promise chain (\switchGuard\) to prevent concurrent switch race conditions
- **disconnect** updated to reuse the same \purgeCache\ pipeline

### api.ts (\src/services/api.ts\)
- Added \ctiveControllers\ Set tracking all in-flight \AbortController\ instances
- Added \bortAllRequests()\ exported function to abort all active requests
- \
equest()\ registers/unregisters its controller via \inally\ block for reliable cleanup

### cache.ts (\src/services/cache.ts\)
- Added \cacheClearByPrefix(prefix)\ to delete IndexedDB entries matching a given key prefix

## Resolution Strategy

1. \cacheVersion\ (useRef) incremented on every purge and exposed via context
2. \switchAccount\ wraps inner logic with \switchGuard\ promise chain (mutex pattern)
3. \purgeCache\ is called inside the mutex, passing the old account address for scoped IndexedDB cleanup
4. \bortAllRequests()\ aborts all tracked AbortControllers from \pi.ts\ on each switch

Closes #1