### PR TITLE
feat: challenge-response cryptographic handshake auth hook (#4)

### DIFF
--- a/src/hooks/useWeb3Auth.ts
+++ b/src/hooks/useWeb3Auth.ts
@@ -1,96 +1,119 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Keypair } from "@stellar/stellar-sdk";
-
-interface AuthSession {
-  address: string;
-  network: string;
-  signature: string;
-  expiresAt: number;
-}
+import { Keypair } from "@stellar/stellar-sdk";
+import {
+  CHALLENGE_DURATION_MS,
+  clearSession,
+  isSessionValid,
+  loadSession,
+  performHandshake,
+  saveSession,
+  signMessage,
+  type AuthSession,
+} from "@/utils/web3Auth";
 
 interface UseWeb3AuthReturn {
   account: { address: string; network: string } | null;
   isConnected: boolean;
   isAuthenticated: boolean;
+  /** True once a session token exists but the in-memory keypair is gone
+   * (e.g. after a reload) — a re-challenge is needed to sign again. */
+  needsReChallenge: boolean;
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
+  /** Sign a challenge for an API auth header. Requires a live keypair. */
   signChallenge: (challenge: string) => Promise<string>;
 }
 
-const CHALLENGE_DURATION_MS = 30 * 60 * 1000;
+export interface UseWeb3AuthOptions {
+  network?: string;
+  /** Inject a keypair factory (tests); defaults to a random keypair. */
+  keypairFactory?: () => Keypair;
+}
 
-export function useWeb3Auth(): UseWeb3AuthReturn {
+export function useWeb3Auth(options: UseWeb3AuthOptions = {}): UseWeb3AuthReturn {
+  const { network = "testnet", keypairFactory } = options;
+
   const [session, setSession] = useState<AuthSession | null>(null);
+  // The keypair (with the secret) lives ONLY here and is never serialized.
   const keypairRef = useRef<Keypair | null>(null);
+  const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
-    const stored = localStorage.getItem("utility-auth-session");
-    if (stored) {
-      try {
-        const parsed: AuthSession = JSON.parse(stored);
-        if (parsed.expiresAt > Date.now()) {
-          setSession(parsed);
-          import("@stellar/stellar-sdk").then(({ Keypair: StellarKeypair }) => {
-            keypairRef.current = StellarKeypair.fromSecret(
-              localStorage.getItem("utility-auth-secret") || ""
-            );
-          }).catch(() => {
-            // Secret is invalid or not available; keypair remains null.
-            // Signing will throw a descriptive error when attempted.
-          });
-        } else {
-          localStorage.removeItem("utility-auth-session");
-          localStorage.removeItem("utility-auth-secret");
-        }
-      } catch {
-        localStorage.removeItem("utility-auth-session");
-        localStorage.removeItem("utility-auth-secret");
-      }
+  const clearExpiryTimer = useCallback(() => {
+    if (expiryTimerRef.current !== null) {
+      clearTimeout(expiryTimerRef.current);
+      expiryTimerRef.current = null;
     }
   }, []);
 
-  const signChallenge = useCallback(async (challenge: string): Promise<string> => {
-    const kp = keypairRef.current;
-    if (!kp) throw new Error("No keypair available for signing");
-    const buffer = Buffer.from(challenge, "utf-8");
-    return kp.sign(buffer).toString("hex");
-  }, []);
+  /** Force the session to expire (re-challenge required) at `expiresAt`. */
+  const scheduleExpiry = useCallback(
+    (expiresAt: number) => {
+      clearExpiryTimer();
+      const delay = Math.max(0, expiresAt - Date.now());
+      expiryTimerRef.current = setTimeout(() => {
+        keypairRef.current = null;
+        setSession(null);
+        clearSession();
+      }, delay);
+    },
+    [clearExpiryTimer]
+  );
+
+  // On mount: restore a still-valid session token (the keypair is NOT restored
+  // — the secret was never stored — so signing needs a re-challenge).
+  useEffect(() => {
+    const restored = loadSession();
+    if (restored) {
+      setSession(restored);
+      scheduleExpiry(restored.expiresAt);
+    }
+    return () => clearExpiryTimer();
+  }, [scheduleExpiry, clearExpiryTimer]);
 
   const connect = useCallback(async () => {
-    const { Keypair: StellarKeypair } = await import("@stellar/stellar-sdk");
-    const kp = StellarKeypair.random();
-    keypairRef.current = kp;
-    const challenge = `Utility-Protocol Auth: ${Date.now()}`;
-    const buffer = Buffer.from(challenge, "utf-8");
-    const signature = kp.sign(buffer).toString("hex");
-    const authSession: AuthSession = {
-      address: kp.publicKey(),
-      network: "testnet",
-      signature,
-      expiresAt: Date.now() + CHALLENGE_DURATION_MS,
-    };
-    localStorage.setItem("utility-auth-session", JSON.stringify(authSession));
-    localStorage.setItem("utility-auth-secret", kp.secret());
-    setSession(authSession);
-  }, []);
+    const keypair = keypairFactory ? keypairFactory() : Keypair.random();
+    // Run the challenge-response handshake; throws if verification fails so a
+    // session is never established without a valid signature.
+    const { session: established } = performHandshake(keypair, network);
+
+    keypairRef.current = keypair;
+    saveSession(established); // token only, never the secret
+    setSession(established);
+    scheduleExpiry(established.expiresAt);
+  }, [keypairFactory, network, scheduleExpiry]);
 
   const disconnect = useCallback(async () => {
+    clearExpiryTimer();
     keypairRef.current = null;
     setSession(null);
-    localStorage.removeItem("utility-auth-session");
-    localStorage.removeItem("utility-auth-secret");
+    clearSession();
+  }, [clearExpiryTimer]);
+
+  const signChallenge = useCallback(async (challenge: string): Promise<string> => {
+    const kp = keypairRef.current;
+    if (!kp) {
+      throw new Error(
+        "No live keypair — reconnect to re-establish the handshake before signing"
+      );
+    }
+    return signMessage(kp, challenge);
   }, []);
+
+  const authenticated = isSessionValid(session);
 
   return {
     account: session
       ? { address: session.address, network: session.network }
       : null,
     isConnected: !!session,
-    isAuthenticated: !!session && session.expiresAt > Date.now(),
+    isAuthenticated: authenticated,
+    needsReChallenge: authenticated && keypairRef.current === null,
     connect,
     disconnect,
     signChallenge,
   };
 }
+
+export { CHALLENGE_DURATION_MS };

--- a/src/utils/web3Auth.ts
+++ b/src/utils/web3Auth.ts
@@ -1,0 +1,165 @@
+/**
+ * Challenge-response handshake primitives for Web3 wallet auth.
+ *
+ * Security model: the keypair's secret never leaves memory and is never
+ * serialized. A session is established by signing a random `challenge + nonce`
+ * and verifying the signature against the (non-expiring) public key. Only the
+ * resulting session token — `{ address, network, signature, expiresAt }` — is
+ * persisted, and it expires after {@link CHALLENGE_DURATION_MS}.
+ */
+
+import { Keypair } from "@stellar/stellar-sdk";
+
+/** A signed challenge token is valid for 30 minutes. */
+export const CHALLENGE_DURATION_MS = 30 * 60 * 1000;
+
+/** localStorage key for the session token (never the secret). */
+export const SESSION_STORAGE_KEY = "utility-auth-session";
+/** Legacy key that previous versions used to (wrongly) store the secret. */
+export const LEGACY_SECRET_KEY = "utility-auth-secret";
+
+export interface AuthSession {
+  address: string;
+  network: string;
+  /** Hex signature over the handshake message. */
+  signature: string;
+  /** Unix ms after which the session is no longer authenticated. */
+  expiresAt: number;
+}
+
+export interface Challenge {
+  challenge: string;
+  nonce: string;
+}
+
+function randomHex(bytes: number): string {
+  const arr = new Uint8Array(bytes);
+  crypto.getRandomValues(arr);
+  let out = "";
+  for (const b of arr) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+/** Generate a fresh random challenge string and nonce. */
+export function generateChallenge(): Challenge {
+  return {
+    challenge: `Utility-Protocol Authentication Challenge: ${randomHex(16)}`,
+    nonce: randomHex(16),
+  };
+}
+
+/** The exact bytes the wallet signs: `challenge` joined with `nonce`. */
+export function handshakeMessage(challenge: string, nonce: string): string {
+  return `${challenge}.${nonce}`;
+}
+
+/** Verify a hex signature over `message` against a Stellar public key. */
+export function verifyHandshake(
+  publicKey: string,
+  message: string,
+  signatureHex: string
+): boolean {
+  try {
+    const kp = Keypair.fromPublicKey(publicKey);
+    return kp.verify(Buffer.from(message, "utf-8"), Buffer.from(signatureHex, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+/** Sign an arbitrary challenge string, returning a hex signature. */
+export function signMessage(keypair: Keypair, message: string): string {
+  return keypair.sign(Buffer.from(message, "utf-8")).toString("hex");
+}
+
+export interface HandshakeResult {
+  session: AuthSession;
+  challenge: Challenge;
+}
+
+/**
+ * Run the full handshake for a keypair: generate a challenge, sign it, verify
+ * the signature against the public key, and return the resulting session token.
+ * Throws if verification fails. The secret is never read out of the keypair.
+ */
+export function performHandshake(
+  keypair: Keypair,
+  network: string,
+  now: number = Date.now()
+): HandshakeResult {
+  const challenge = generateChallenge();
+  const message = handshakeMessage(challenge.challenge, challenge.nonce);
+  const signature = signMessage(keypair, message);
+
+  if (!verifyHandshake(keypair.publicKey(), message, signature)) {
+    throw new Error("Handshake signature verification failed");
+  }
+
+  return {
+    session: {
+      address: keypair.publicKey(),
+      network,
+      signature,
+      expiresAt: now + CHALLENGE_DURATION_MS,
+    },
+    challenge,
+  };
+}
+
+/** A session is valid only while it has not expired. */
+export function isSessionValid(
+  session: AuthSession | null,
+  now: number = Date.now()
+): session is AuthSession {
+  return session !== null && session.expiresAt > now;
+}
+
+// --- Persistence (token only; never the secret) ----------------------------
+
+function getStorage(): Pick<Storage, "getItem" | "setItem" | "removeItem"> | null {
+  try {
+    return typeof localStorage !== "undefined" ? localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Load and validate a stored session; expired/corrupt tokens are purged. */
+export function loadSession(now: number = Date.now()): AuthSession | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  const raw = storage.getItem(SESSION_STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as AuthSession;
+    if (!isSessionValid(parsed, now)) {
+      clearSession();
+      return null;
+    }
+    return parsed;
+  } catch {
+    clearSession();
+    return null;
+  }
+}
+
+/** Persist the session token. Strips any field that isn't part of the token. */
+export function saveSession(session: AuthSession): void {
+  const storage = getStorage();
+  if (!storage) return;
+  const token: AuthSession = {
+    address: session.address,
+    network: session.network,
+    signature: session.signature,
+    expiresAt: session.expiresAt,
+  };
+  storage.setItem(SESSION_STORAGE_KEY, JSON.stringify(token));
+}
+
+/** Remove every session artifact, including the legacy plaintext secret. */
+export function clearSession(): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.removeItem(SESSION_STORAGE_KEY);
+  storage.removeItem(LEGACY_SECRET_KEY);
+}

--- a/tests/hooks/useWeb3Auth.test.ts
+++ b/tests/hooks/useWeb3Auth.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWeb3Auth } from "@/hooks/useWeb3Auth";
+import type { Keypair } from "@stellar/stellar-sdk";
+
+// The crypto util is unit-tested for real in tests/unit/web3Auth.test.ts (node
+// env). Here we mock it so the hook's orchestration (state, storage, expiry,
+// re-challenge) can be tested under jsdom without ed25519's realm constraints.
+const h = vi.hoisted(() => ({ store: null as Record<string, unknown> | null }));
+
+vi.mock("@/utils/web3Auth", () => ({
+  CHALLENGE_DURATION_MS: 1_800_000,
+  isSessionValid: (s: { expiresAt: number } | null, now = Date.now()) =>
+    !!s && s.expiresAt > now,
+  loadSession: () => {
+    const s = h.store as { expiresAt: number } | null;
+    if (s && s.expiresAt > Date.now()) return s;
+    h.store = null;
+    return null;
+  },
+  saveSession: (s: Record<string, unknown>) => {
+    h.store = { ...s };
+  },
+  clearSession: () => {
+    h.store = null;
+  },
+  performHandshake: (kp: { publicKey: () => string }, network: string, now = Date.now()) => ({
+    session: {
+      address: kp.publicKey(),
+      network,
+      signature: "sig",
+      expiresAt: now + 1_800_000,
+    },
+    challenge: { challenge: "c", nonce: "n" },
+  }),
+  signMessage: (_kp: unknown, msg: string) => `signed:${msg}`,
+}));
+
+/** A fake keypair good enough for the (mocked) handshake. */
+function fakeKeypair(address = "G" + "A".repeat(55)): Keypair {
+  return {
+    publicKey: () => address,
+    secret: () => "S" + "B".repeat(55),
+    sign: () => Buffer.from("sig"),
+  } as unknown as Keypair;
+}
+
+beforeEach(() => {
+  h.store = null;
+  vi.clearAllMocks();
+});
+
+describe("useWeb3Auth", () => {
+  it("starts disconnected", () => {
+    const { result } = renderHook(() => useWeb3Auth());
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.account).toBeNull();
+  });
+
+  it("establishes a verified session on connect", async () => {
+    const kp = fakeKeypair("GABC");
+    const { result } = renderHook(() => useWeb3Auth({ keypairFactory: () => kp }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.account?.address).toBe("GABC");
+    expect(result.current.needsReChallenge).toBe(false);
+    // Token persisted via the (mocked) util.
+    expect(h.store).toMatchObject({ address: "GABC", network: "testnet" });
+  });
+
+  it("signChallenge signs with the live keypair", async () => {
+    const { result } = renderHook(() =>
+      useWeb3Auth({ keypairFactory: () => fakeKeypair() })
+    );
+    await act(async () => {
+      await result.current.connect();
+    });
+    await expect(result.current.signChallenge("api-nonce")).resolves.toBe(
+      "signed:api-nonce"
+    );
+  });
+
+  it("wipes session and storage on disconnect", async () => {
+    const { result } = renderHook(() =>
+      useWeb3Auth({ keypairFactory: () => fakeKeypair() })
+    );
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(result.current.isConnected).toBe(true);
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.account).toBeNull();
+    expect(h.store).toBeNull();
+  });
+
+  it("restores a valid token on mount but flags re-challenge (no keypair)", () => {
+    h.store = {
+      address: "GREST",
+      network: "testnet",
+      signature: "sig",
+      expiresAt: Date.now() + 1_800_000,
+    };
+    const { result } = renderHook(() => useWeb3Auth());
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.account?.address).toBe("GREST");
+    expect(result.current.needsReChallenge).toBe(true);
+  });
+
+  it("rejects signing when there is no live keypair", async () => {
+    h.store = {
+      address: "GREST",
+      network: "testnet",
+      signature: "sig",
+      expiresAt: Date.now() + 1_800_000,
+    };
+    const { result } = renderHook(() => useWeb3Auth());
+    await expect(result.current.signChallenge("x")).rejects.toThrow(/reconnect/);
+  });
+
+  it("does not restore an expired token", () => {
+    h.store = {
+      address: "GOLD",
+      network: "testnet",
+      signature: "sig",
+      expiresAt: Date.now() - 1000,
+    };
+    const { result } = renderHook(() => useWeb3Auth());
+    expect(result.current.isConnected).toBe(false);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -18,6 +18,10 @@ const localStorageMock = (() => {
   };
 })();
 
-Object.defineProperty(window, 'localStorage', {
-  value: localStorageMock,
-});
+// Only patch window.localStorage under a DOM environment (jsdom). Node-env
+// tests (e.g. real-crypto suites) provide their own storage shim if needed.
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'localStorage', {
+    value: localStorageMock,
+  });
+}

--- a/tests/unit/web3Auth.test.ts
+++ b/tests/unit/web3Auth.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+//
+// Real ed25519 (Stellar Keypair via @noble/curves) only works in the node
+// environment — under jsdom the Uint8Array realm mismatch makes Keypair.random
+// throw. A tiny localStorage shim covers the persistence helpers here.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { Keypair } from "@stellar/stellar-sdk";
+import {
+  generateChallenge,
+  handshakeMessage,
+  verifyHandshake,
+  signMessage,
+  performHandshake,
+  isSessionValid,
+  saveSession,
+  loadSession,
+  clearSession,
+  CHALLENGE_DURATION_MS,
+  SESSION_STORAGE_KEY,
+  LEGACY_SECRET_KEY,
+  type AuthSession,
+} from "@/utils/web3Auth";
+
+const store = new Map<string, string>();
+(globalThis as unknown as { localStorage: Storage }).localStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => void store.set(k, String(v)),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+  key: () => null,
+  length: 0,
+} as Storage;
+
+beforeEach(() => store.clear());
+
+describe("generateChallenge / handshakeMessage", () => {
+  it("produces distinct random challenge and nonce", () => {
+    const a = generateChallenge();
+    const b = generateChallenge();
+    expect(a.challenge).not.toBe(b.challenge);
+    expect(a.nonce).not.toBe(b.nonce);
+    expect(a.nonce).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("joins challenge and nonce deterministically", () => {
+    expect(handshakeMessage("c", "n")).toBe("c.n");
+  });
+});
+
+describe("verifyHandshake / signMessage", () => {
+  it("verifies a signature produced by the matching keypair", () => {
+    const kp = Keypair.random();
+    const msg = handshakeMessage("challenge", "nonce");
+    expect(verifyHandshake(kp.publicKey(), msg, signMessage(kp, msg))).toBe(true);
+  });
+
+  it("rejects a tampered message", () => {
+    const kp = Keypair.random();
+    const sig = signMessage(kp, "original");
+    expect(verifyHandshake(kp.publicKey(), "tampered", sig)).toBe(false);
+  });
+
+  it("rejects a signature from a different keypair", () => {
+    const kp = Keypair.random();
+    const other = Keypair.random();
+    expect(verifyHandshake(other.publicKey(), "m", signMessage(kp, "m"))).toBe(false);
+  });
+
+  it("rejects malformed inputs without throwing", () => {
+    expect(verifyHandshake("not-a-key", "m", "00")).toBe(false);
+  });
+});
+
+describe("performHandshake", () => {
+  it("returns a verified session bound to the public key", () => {
+    const kp = Keypair.random();
+    const { session, challenge } = performHandshake(kp, "testnet", 1000);
+    expect(session.address).toBe(kp.publicKey());
+    expect(session.network).toBe("testnet");
+    expect(session.expiresAt).toBe(1000 + CHALLENGE_DURATION_MS);
+    const msg = handshakeMessage(challenge.challenge, challenge.nonce);
+    expect(verifyHandshake(session.address, msg, session.signature)).toBe(true);
+  });
+
+  it("never includes the secret in the session token", () => {
+    const { session } = performHandshake(Keypair.random(), "testnet");
+    expect(Object.keys(session)).toEqual([
+      "address",
+      "network",
+      "signature",
+      "expiresAt",
+    ]);
+  });
+});
+
+describe("isSessionValid", () => {
+  const base: AuthSession = {
+    address: "G".repeat(56),
+    network: "testnet",
+    signature: "00",
+    expiresAt: 0,
+  };
+
+  it("is true only before expiry", () => {
+    expect(isSessionValid({ ...base, expiresAt: 2000 }, 1000)).toBe(true);
+    expect(isSessionValid({ ...base, expiresAt: 1000 }, 1000)).toBe(false);
+    expect(isSessionValid(null)).toBe(false);
+  });
+});
+
+describe("session persistence", () => {
+  const session: AuthSession = {
+    address: "G".repeat(56),
+    network: "testnet",
+    signature: "abcd",
+    expiresAt: Date.now() + CHALLENGE_DURATION_MS,
+  };
+
+  it("round-trips a valid token", () => {
+    saveSession(session);
+    expect(loadSession()).toEqual(session);
+  });
+
+  it("never persists a secret, even if one is passed in", () => {
+    const withSecret = { ...session, secret: "S-SECRET" } as unknown as AuthSession;
+    saveSession(withSecret);
+    const raw = store.get(SESSION_STORAGE_KEY)!;
+    expect(raw).not.toContain("secret");
+    expect(raw).not.toContain("S-SECRET");
+  });
+
+  it("purges an expired token on load", () => {
+    saveSession({ ...session, expiresAt: Date.now() - 1 });
+    expect(loadSession()).toBeNull();
+    expect(store.get(SESSION_STORAGE_KEY)).toBeUndefined();
+  });
+
+  it("purges corrupt JSON on load", () => {
+    store.set(SESSION_STORAGE_KEY, "not-json{");
+    expect(loadSession()).toBeNull();
+  });
+
+  it("clearSession removes the token and the legacy secret key", () => {
+    saveSession(session);
+    store.set(LEGACY_SECRET_KEY, "S-LEGACY");
+    clearSession();
+    expect(store.get(SESSION_STORAGE_KEY)).toBeUndefined();
+    expect(store.get(LEGACY_SECRET_KEY)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Challenge-Response Cryptographic Handshake Hook Lifecycle (#4)

Closes #4

## Changes

| File | Responsibility |
|------|----------------|
| `src/utils/web3Auth.ts` (new) | `generateChallenge` (random challenge + nonce), `handshakeMessage`, `signMessage`, `verifyHandshake` (against the public key), `performHandshake` (sign → **verify** → session token; throws on verification failure), `isSessionValid`, and token-only persistence: `saveSession` strips any secret, `loadSession` purges expired/corrupt tokens, `clearSession` also removes the legacy secret key. |
| `src/hooks/useWeb3Auth.ts` (rewritten) | The keypair (secret) lives **only in a `useRef`** and is never serialized. `connect` runs the verified handshake and persists only `{address, network, signature, expiresAt}`. A timer force-expires the session at `CHALLENGE_DURATION_MS` (30 min). `signChallenge` requires a live keypair and the hook exposes `needsReChallenge` after a reload (token restored, but signing needs a fresh handshake). `disconnect` wipes context + storage. The existing `account`/`isConnected`/`connect`/`disconnect` surface is preserved. |
| `tests/unit/web3Auth.test.ts` | Real ed25519 handshake/verify/persistence. |
| `tests/hooks/useWeb3Auth.test.ts` | Hook orchestration: connect/disconnect, restore-on-mount, expiry, re-challenge, sign-requires-keypair. |
| `tests/setup.ts` | Guards `window` access so node-env suites can run. |
