### PR TITLE
Audit trail with tamper evident

### DIFF
--- a/docs/audit-trail-hash-chain.md
+++ b/docs/audit-trail-hash-chain.md
@@ -1,0 +1,31 @@
+# Audit Trail with Tamper-Evident Hash Chain Verification
+
+## Architecture
+
+Each service emits append-only audit records for security-relevant actions. Records are serialized with canonical JSON, linked to the prior record hash, and hashed with SHA-256. The genesis record uses an all-zero hash so independent verifiers can replay a stream without shared mutable state.
+
+The initial frontend implementation provides the deterministic hash-chain primitives used by service clients, export verification, and future monitoring integrations.
+
+## Record contract
+
+- `sequence`: monotonically increasing record number.
+- `previousHash`: SHA-256 hash of the previous record, or the genesis hash for the first record.
+- `hash`: SHA-256 over the canonical record without the `hash` field.
+- `payload`: service-specific audit details. Object keys are sorted recursively before hashing.
+
+## Verification
+
+Verification replays records in order and checks:
+
+1. sequence continuity;
+2. previous-hash linkage;
+3. the stored hash against a freshly calculated hash.
+
+Any mismatch is returned as a structured issue suitable for alerting, dashboards, and runbooks. A valid result includes the verified record count and current head hash for anchoring in external storage.
+
+## Operational plan
+
+- Monitor verification failures by issue reason and service.
+- Alert security on any `hash_mismatch` or `previous_hash_mismatch`.
+- Run canaries by shadow-verifying production audit streams before enabling enforcement.
+- During blue-green deployments, compare old and new head hashes for the same replay window before shifting traffic.

--- a/src/services/audit/hashChain.ts
+++ b/src/services/audit/hashChain.ts
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+
+export type AuditPayload = Record<string, unknown>;
+
+export interface AuditRecordInput {
+  id: string;
+  action: string;
+  actorId: string;
+  service: string;
+  occurredAt: string;
+  payload: AuditPayload;
+}
+
+export interface AuditRecord extends AuditRecordInput {
+  previousHash: string;
+  hash: string;
+  sequence: number;
+}
+
+export interface AuditVerificationIssue {
+  sequence: number;
+  id: string;
+  reason: "sequence_gap" | "previous_hash_mismatch" | "hash_mismatch";
+  expected: string | number;
+  actual: string | number;
+}
+
+export interface AuditVerificationResult {
+  valid: boolean;
+  headHash: string;
+  verifiedRecords: number;
+  issues: AuditVerificationIssue[];
+}
+
+export const AUDIT_GENESIS_HASH = "0".repeat(64);
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((canonical, key) => {
+        canonical[key] = canonicalize((value as Record<string, unknown>)[key]);
+        return canonical;
+      }, {});
+  }
+
+  return value;
+}
+
+export function canonicalAuditJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function calculateAuditHash(record: Omit<AuditRecord, "hash">): string {
+  return createHash("sha256")
+    .update(canonicalAuditJson(record))
+    .digest("hex");
+}
+
+export function appendAuditRecord(
+  chain: readonly AuditRecord[],
+  input: AuditRecordInput,
+): AuditRecord {
+  const previous = chain.at(-1);
+  const recordWithoutHash: Omit<AuditRecord, "hash"> = {
+    ...input,
+    previousHash: previous?.hash ?? AUDIT_GENESIS_HASH,
+    sequence: (previous?.sequence ?? 0) + 1,
+  };
+
+  return {
+    ...recordWithoutHash,
+    hash: calculateAuditHash(recordWithoutHash),
+  };
+}
+
+export function verifyAuditChain(records: readonly AuditRecord[]): AuditVerificationResult {
+  const issues: AuditVerificationIssue[] = [];
+  let previousHash = AUDIT_GENESIS_HASH;
+  let expectedSequence = 1;
+
+  for (const record of records) {
+    if (record.sequence !== expectedSequence) {
+      issues.push({
+        sequence: record.sequence,
+        id: record.id,
+        reason: "sequence_gap",
+        expected: expectedSequence,
+        actual: record.sequence,
+      });
+    }
+
+    if (record.previousHash !== previousHash) {
+      issues.push({
+        sequence: record.sequence,
+        id: record.id,
+        reason: "previous_hash_mismatch",
+        expected: previousHash,
+        actual: record.previousHash,
+      });
+    }
+
+    const { hash, ...recordWithoutHash } = record;
+    void hash;
+    const expectedHash = calculateAuditHash(recordWithoutHash);
+    if (record.hash !== expectedHash) {
+      issues.push({
+        sequence: record.sequence,
+        id: record.id,
+        reason: "hash_mismatch",
+        expected: expectedHash,
+        actual: record.hash,
+      });
+    }
+
+    previousHash = record.hash;
+    expectedSequence = record.sequence + 1;
+  }
+
+  return {
+    valid: issues.length === 0,
+    headHash: records.at(-1)?.hash ?? AUDIT_GENESIS_HASH,
+    verifiedRecords: records.length,
+    issues,
+  };
+}

--- a/tests/auditHashChain.test.ts
+++ b/tests/auditHashChain.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendAuditRecord,
+  AUDIT_GENESIS_HASH,
+  calculateAuditHash,
+  verifyAuditChain,
+  type AuditRecord,
+} from "@/services/audit/hashChain";
+
+const baseInput = {
+  actorId: "system:billing-api",
+  service: "billing-api",
+  occurredAt: "2026-07-18T00:00:00.000Z",
+  payload: { invoiceId: "inv_123", amountCents: 4200, tags: ["utility", "settlement"] },
+};
+
+describe("audit hash chain", () => {
+  it("appends records with deterministic hashes and verifies the chain", () => {
+    const first = appendAuditRecord([], { ...baseInput, id: "evt_1", action: "invoice.created" });
+    const second = appendAuditRecord([first], { ...baseInput, id: "evt_2", action: "invoice.approved" });
+
+    expect(first.sequence).toBe(1);
+    expect(first.previousHash).toBe(AUDIT_GENESIS_HASH);
+    expect(second.sequence).toBe(2);
+    expect(second.previousHash).toBe(first.hash);
+    expect(verifyAuditChain([first, second])).toEqual({
+      valid: true,
+      headHash: second.hash,
+      verifiedRecords: 2,
+      issues: [],
+    });
+  });
+
+  it("canonicalizes payload key order before hashing", () => {
+    const a = appendAuditRecord([], {
+      ...baseInput,
+      id: "evt_1",
+      action: "asset.updated",
+      payload: { z: 1, a: { y: true, b: false } },
+    });
+    const b = appendAuditRecord([], {
+      ...baseInput,
+      id: "evt_1",
+      action: "asset.updated",
+      payload: { a: { b: false, y: true }, z: 1 },
+    });
+
+    expect(a.hash).toBe(b.hash);
+  });
+
+  it("reports tampering to payloads, previous hashes, and sequence gaps", () => {
+    const first = appendAuditRecord([], { ...baseInput, id: "evt_1", action: "meter.read" });
+    const second = appendAuditRecord([first], { ...baseInput, id: "evt_2", action: "meter.export" });
+    const tampered: AuditRecord = {
+      ...second,
+      sequence: 4,
+      previousHash: "f".repeat(64),
+      payload: { ...second.payload, amountCents: 1 },
+    };
+
+    const result = verifyAuditChain([first, tampered]);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.reason)).toEqual([
+      "sequence_gap",
+      "previous_hash_mismatch",
+      "hash_mismatch",
+    ]);
+    const { hash, ...tamperedWithoutHash } = tampered;
+    void hash;
+    expect(calculateAuditHash(tamperedWithoutHash)).not.toBe(second.hash);
+  });
+});


### PR DESCRIPTION
Motivation
Provide deterministic, tamper-evident audit primitives so services and clients can produce and verify append-only audit trails with a minimal, portable implementation.
Enable detection and structured reporting of sequence gaps, broken previous-hash links, and record hash mismatches for monitoring and runbooks.
Description
Add src/services/audit/hashChain.ts implementing canonicalAuditJson, calculateAuditHash, appendAuditRecord, and verifyAuditChain with a genesis hash and structured AuditVerificationIssue results.
Add unit tests in tests/auditHashChain.test.ts covering valid chains, canonicalization of payload ordering, and tamper detection for sequence, previous-hash, and payload changes.
Add documentation docs/audit-trail-hash-chain.md describing the architecture, record contract, verification steps, and operational guidance for canary/blue-green deployments.
Testing
git diff --check ran successfully with no new issues reported.
npm test -- tests/auditHashChain.test.ts ran the new test file and all tests passed (3 tests).
npx tsc --noEmit passed with no TypeScript errors.
npm run lint remains blocked by pre-existing unused-variable errors in src/components/map/AssetHeatmapLayer.tsx, which are unrelated to these changes.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/137