### PR TITLE
End to end encryption

### DIFF
--- a/docs/security/sensitive-payload-encryption.md
+++ b/docs/security/sensitive-payload-encryption.md
@@ -1,0 +1,47 @@
+# Sensitive Payload Field Encryption
+
+## Architecture
+
+Sensitive payload field encryption runs in the API client before JSON request bodies leave the browser. Callers provide a non-extractable WebCrypto `CryptoKey` and key id (`kid`) through the API request config. The client recursively walks request bodies and replaces configured sensitive fields with an AES-GCM envelope.
+
+```json
+{
+  "__type": "encrypted-field",
+  "version": 1,
+  "alg": "AES-GCM",
+  "kid": "tenant-key-2026-07",
+  "iv": "base64 nonce",
+  "ciphertext": "base64 ciphertext plus auth tag"
+}
+```
+
+Default sensitive fields include tokens, account numbers, contact fields, secrets, and private keys. Services can extend that list per request with `sensitiveFieldNames` so domain payloads can add regulated identifiers without changing shared code.
+
+## Security controls
+
+- AES-GCM uses a fresh 96-bit IV for every encrypted field.
+- Raw key material is imported as a non-extractable WebCrypto key.
+- Already encrypted envelopes are left untouched to prevent double encryption.
+- Encryption is explicit and fail-closed: if WebCrypto is unavailable or key material is invalid, the request fails before transmission.
+
+## Performance target
+
+The frontend measures encryption duration for each request body and logs a warning when encrypted payload preparation exceeds the 100 ms critical-path target. Production telemetry should capture this warning as `sensitive_payload_encryption.duration_ms` with tags for route, key id, and encrypted field count.
+
+## Monitoring and alerting
+
+Recommended service-level indicators:
+
+- P99 encryption duration < 100 ms over 5 minutes.
+- Encryption failure rate < 0.01% over 5 minutes.
+- Payloads containing configured sensitive field names without encrypted envelopes: zero tolerated.
+
+Alert when P99 duration exceeds 100 ms for two consecutive windows or when any plaintext sensitive-field detector fires in edge/service logs.
+
+## Deployment runbook
+
+1. Deploy backend envelope parsing and key-resolution support behind a disabled feature flag.
+2. Deploy this frontend encryption path disabled by default.
+3. Enable canary traffic for one tenant or environment and verify decrypt success, latency, and plaintext-detector dashboards.
+4. Expand using blue-green deployment. Keep the previous green stack available until decrypt errors remain below threshold for one full rotation window.
+5. Rotate keys by publishing a new `kid`, accepting old and new key ids during the overlap, then retiring the old key after queued/offline requests drain.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -6,6 +6,7 @@ interface ApiConfig {
   baseUrl: string;
   headers: Record<string, string>;
   timeout: number;
+  sensitivePayloadEncryption?: import("./sensitivePayloadEncryption").SensitivePayloadEncryptionOptions;
 }
 
 interface ApiResponse<T = unknown> {
@@ -40,6 +41,18 @@ export function abortAllRequests(): void {
   activeControllers.clear();
 }
 
+async function prepareRequestBody(body: unknown, config: ApiConfig): Promise<unknown> {
+  if (!config.sensitivePayloadEncryption) return body;
+  const { encryptSensitivePayload } = await import("./sensitivePayloadEncryption");
+  const result = await encryptSensitivePayload(body, config.sensitivePayloadEncryption);
+  if (result.encryptedFieldCount > 0) {
+    if (result.durationMs > 100) {
+      console.warn(`Sensitive payload encryption exceeded 100ms target: ${result.durationMs.toFixed(1)}ms`);
+    }
+  }
+  return result.payload;
+}
+
 async function request<T>(
   method: HttpMethod,
   path: string,
@@ -61,7 +74,7 @@ async function request<T>(
     const response = await fetch(url, {
       method,
       headers,
-      body: body ? JSON.stringify(body) : undefined,
+      body: body ? JSON.stringify(await prepareRequestBody(body, cfg)) : undefined,
       signal: controller.signal,
     });
 

--- a/src/services/sensitivePayloadEncryption.ts
+++ b/src/services/sensitivePayloadEncryption.ts
@@ -1,0 +1,161 @@
+const ENCRYPTION_VERSION = 1;
+const ALGORITHM = "AES-GCM";
+const IV_BYTES = 12;
+const DEFAULT_SENSITIVE_FIELD_NAMES = new Set([
+  "accountNumber",
+  "address",
+  "apiKey",
+  "authToken",
+  "cardNumber",
+  "email",
+  "meterSerial",
+  "phone",
+  "privateKey",
+  "secret",
+  "sessionToken",
+  "ssn",
+  "token",
+]);
+
+export interface EncryptedFieldEnvelope {
+  __type: "encrypted-field";
+  version: typeof ENCRYPTION_VERSION;
+  alg: typeof ALGORITHM;
+  kid: string;
+  iv: string;
+  ciphertext: string;
+}
+
+export interface SensitivePayloadEncryptionOptions {
+  keyId: string;
+  key: CryptoKey;
+  sensitiveFieldNames?: Iterable<string>;
+}
+
+export interface EncryptPayloadResult<T = unknown> {
+  payload: T;
+  encryptedFieldCount: number;
+  durationMs: number;
+}
+
+type Path = Array<string | number>;
+type SensitiveMatcher = (path: Path, value: unknown) => boolean;
+
+function getCrypto(): Crypto {
+  const cryptoImpl = globalThis.crypto;
+  if (!cryptoImpl?.subtle) {
+    throw new Error("WebCrypto SubtleCrypto is required for sensitive payload encryption");
+  }
+  return cryptoImpl;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isEncryptedEnvelope(value: unknown): value is EncryptedFieldEnvelope {
+  return (
+    isRecord(value) &&
+    value.__type === "encrypted-field" &&
+    value.version === ENCRYPTION_VERSION &&
+    value.alg === ALGORITHM &&
+    typeof value.kid === "string" &&
+    typeof value.iv === "string" &&
+    typeof value.ciphertext === "string"
+  );
+}
+
+function toBase64(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join("");
+  if (typeof btoa === "function") return btoa(binary);
+  return Buffer.from(bytes).toString("base64");
+}
+
+function fromBase64(value: string): Uint8Array {
+  if (typeof atob === "function") {
+    return Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+  }
+  return Uint8Array.from(Buffer.from(value, "base64"));
+}
+
+function buildMatcher(fieldNames?: Iterable<string>): SensitiveMatcher {
+  const names = new Set(DEFAULT_SENSITIVE_FIELD_NAMES);
+  for (const name of fieldNames ?? []) names.add(name);
+  return (path) => {
+    const field = path[path.length - 1];
+    return typeof field === "string" && names.has(field);
+  };
+}
+
+async function encryptValue(value: unknown, options: SensitivePayloadEncryptionOptions) {
+  const cryptoImpl = getCrypto();
+  const iv = cryptoImpl.getRandomValues(new Uint8Array(IV_BYTES));
+  const plaintext = new TextEncoder().encode(JSON.stringify(value));
+  const ciphertext = new Uint8Array(
+    await cryptoImpl.subtle.encrypt({ name: ALGORITHM, iv: iv as BufferSource }, options.key, plaintext)
+  );
+
+  return {
+    __type: "encrypted-field",
+    version: ENCRYPTION_VERSION,
+    alg: ALGORITHM,
+    kid: options.keyId,
+    iv: toBase64(iv),
+    ciphertext: toBase64(ciphertext),
+  } satisfies EncryptedFieldEnvelope;
+}
+
+export async function importSensitivePayloadKey(rawKey: Uint8Array | ArrayBuffer): Promise<CryptoKey> {
+  const keyBytes = rawKey instanceof Uint8Array ? rawKey : new Uint8Array(rawKey);
+  if (![16, 24, 32].includes(keyBytes.byteLength)) {
+    throw new Error("Sensitive payload key must be 128, 192, or 256 bits");
+  }
+  return getCrypto().subtle.importKey("raw", keyBytes as BufferSource, ALGORITHM, false, ["encrypt", "decrypt"]);
+}
+
+export async function encryptSensitivePayload<T>(
+  payload: T,
+  options: SensitivePayloadEncryptionOptions
+): Promise<EncryptPayloadResult<T>> {
+  const started = performance.now();
+  const matcher = buildMatcher(options.sensitiveFieldNames);
+  let encryptedFieldCount = 0;
+
+  async function visit(value: unknown, path: Path): Promise<unknown> {
+    if (isEncryptedEnvelope(value)) return value;
+    if (matcher(path, value) && value !== null && value !== undefined) {
+      encryptedFieldCount += 1;
+      return encryptValue(value, options);
+    }
+    if (Array.isArray(value)) return Promise.all(value.map((item, index) => visit(item, [...path, index])));
+    if (isRecord(value)) {
+      const entries = await Promise.all(
+        Object.entries(value).map(async ([key, child]) => [key, await visit(child, [...path, key])] as const)
+      );
+      return Object.fromEntries(entries);
+    }
+    return value;
+  }
+
+  return {
+    payload: (await visit(payload, [])) as T,
+    encryptedFieldCount,
+    durationMs: performance.now() - started,
+  };
+}
+
+export async function decryptEncryptedField<T = unknown>(
+  envelope: EncryptedFieldEnvelope,
+  key: CryptoKey
+): Promise<T> {
+  const plaintext = await getCrypto().subtle.decrypt(
+    { name: ALGORITHM, iv: fromBase64(envelope.iv) as BufferSource },
+    key,
+    fromBase64(envelope.ciphertext) as BufferSource
+  );
+  return JSON.parse(new TextDecoder().decode(plaintext)) as T;
+}
+
+export function isSensitiveFieldEncrypted(value: unknown): value is EncryptedFieldEnvelope {
+  return isEncryptedEnvelope(value);
+}

--- a/tests/unit/sensitivePayloadEncryption.test.ts
+++ b/tests/unit/sensitivePayloadEncryption.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  decryptEncryptedField,
+  encryptSensitivePayload,
+  importSensitivePayloadKey,
+  isSensitiveFieldEncrypted,
+  type EncryptedFieldEnvelope,
+} from "@/services/sensitivePayloadEncryption";
+
+
+const keyBytes = new Uint8Array(32).fill(7);
+
+describe("sensitive payload encryption", () => {
+  it("encrypts default and caller-provided sensitive fields recursively", async () => {
+    const key = await importSensitivePayloadKey(keyBytes);
+    const result = await encryptSensitivePayload(
+      { id: "reading-1", token: "secret-token", nested: { meterSerial: "m-123", customId: "c-456" } },
+      { key, keyId: "kid-1", sensitiveFieldNames: ["customId"] }
+    );
+
+    expect(result.encryptedFieldCount).toBe(3);
+    expect(result.payload.id).toBe("reading-1");
+    expect(isSensitiveFieldEncrypted(result.payload.token)).toBe(true);
+    expect(isSensitiveFieldEncrypted(result.payload.nested.meterSerial)).toBe(true);
+    expect(isSensitiveFieldEncrypted(result.payload.nested.customId)).toBe(true);
+    expect(result.payload.token).not.toEqual("secret-token");
+
+    await expect(decryptEncryptedField(result.payload.token as unknown as EncryptedFieldEnvelope, key)).resolves.toBe("secret-token");
+    await expect(decryptEncryptedField(result.payload.nested.customId as unknown as EncryptedFieldEnvelope, key)).resolves.toBe("c-456");
+  });
+
+  it("does not double-encrypt existing envelopes", async () => {
+    const key = await importSensitivePayloadKey(keyBytes);
+    const first = await encryptSensitivePayload({ token: "secret-token" }, { key, keyId: "kid-1" });
+    const second = await encryptSensitivePayload(first.payload, { key, keyId: "kid-1" });
+
+    expect(second.encryptedFieldCount).toBe(0);
+    expect(second.payload).toEqual(first.payload);
+  });
+
+  it("rejects invalid key lengths", async () => {
+    await expect(importSensitivePayloadKey(new Uint8Array(8))).rejects.toThrow("128, 192, or 256 bits");
+  });
+});


### PR DESCRIPTION
Motivation
Implement client-side end-to-end encryption of sensitive fields so request bodies can be safely transmitted and decrypted by backends, meeting the security requirement for encrypting tokens, secrets, and regulated identifiers.
Provide a pluggable, per-request way to supply a non-extractable WebCrypto CryptoKey and kid so services can adopt encryption incrementally without changing shared payload shapes.
Prevent double-encryption and keep encryption fail-closed while measuring duration against the 100 ms P99 performance target.
Description
Added src/services/sensitivePayloadEncryption.ts which implements AES-GCM field-level encryption and decryption, envelope format detection, default sensitive field names, per-request sensitiveFieldNames extension, and helpers importSensitivePayloadKey, encryptSensitivePayload, decryptEncryptedField, and isSensitiveFieldEncrypted.
Wired optional encryption into the shared API client by adding a sensitivePayloadEncryption field to ApiConfig and a prepareRequestBody helper in src/services/api.ts that runs encryptSensitivePayload before JSON serialization and logs a warning when the encryption step exceeds 100 ms.
Added documentation docs/security/sensitive-payload-encryption.md describing architecture, security controls, monitoring/alerting targets, and a blue-green / canary deployment runbook.
Added unit tests tests/unit/sensitivePayloadEncryption.test.ts covering recursive encryption, custom field extension, decrypt round-trips, double-encryption prevention, and invalid-key rejection.
Testing
Ran the new unit tests with npm test -- tests/unit/sensitivePayloadEncryption.test.ts, and the suite passed (3 tests passed).
Type checking with npx tsc --noEmit succeeded for the changes introduced.
Ran npm run lint which surfaced pre-existing lint errors unrelated to this change (src/components/map/AssetHeatmapLayer.tsx unused-variable errors).
Ran the full test run npm test which exposed pre-existing unrelated failures (tile-key expectation mismatches in tests/components/AssetHeatmapLayer.test.tsx and a SubtleCrypto input handling issue in tests/unit/keyCache.test.ts), while the newly added sensitive-payload tests still passed.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/136