### PR TITLE
Capacity planning with historical

### DIFF
--- a/docs/capacity-planning.md
+++ b/docs/capacity-planning.md
@@ -1,0 +1,30 @@
+# Capacity Planning with Historical Usage Trending
+
+## Architecture
+
+The capacity planner is a pure TypeScript module that consumes historical meter readings, aggregates them into fixed-width windows, calculates positive historical growth, and projects future utilization for water, energy, and bandwidth resources. It depends on the existing exact BigInt aggregation pipeline, so planning totals remain deterministic and avoid cumulative floating-point drift.
+
+## Operational targets
+
+- Critical-path planning is O(readings + resources × windows) and performs no network I/O, which keeps it suitable for sub-100 ms dashboard or worker execution on bounded history windows.
+- The module is side-effect free except for the `generatedAt` timestamp, making it safe to run during blue-green deploys and canary comparisons.
+- Capacity limits are passed in explicitly to keep authorization and secret access outside the planning core.
+
+## Monitoring and alerts
+
+Export these derived values per resource:
+
+- `capacity_projected_utilization_ratio`
+- `capacity_trend_per_window_base_units`
+- `capacity_exhausted_at_window`
+- `capacity_status{status="healthy|watch|critical"}`
+
+Alert when projected utilization is at least 80% (`watch`) and page when it is at least 95% (`critical`) or already exhausted.
+
+## Runbook
+
+1. Compare current and projected utilization across the active and canary environments.
+2. Validate that meter-ingestion lag is within its SLO before trusting a capacity deficit.
+3. Increase provisioned capacity to at least `recommendedCapacityBase` for the affected resource.
+4. Keep the canary below 25% traffic until projected utilization returns below 80% for two consecutive planning windows.
+5. Roll back the canary if the planner reports divergent status from the active environment for the same historical window.

--- a/src/utils/capacityPlanning.ts
+++ b/src/utils/capacityPlanning.ts
@@ -1,0 +1,152 @@
+import { aggregateReadings, type Reading } from "@/utils/aggregation/resourceMath";
+import { RESOURCE_TYPES, type ResourceType } from "@/utils/aggregation/unitConversion";
+
+export interface HistoricalReading extends Reading {
+  /** Unix milliseconds. */
+  timestamp: number;
+}
+
+export interface CapacityLimit {
+  resource: ResourceType;
+  /** Provisioned capacity in base resource units for one planning window. */
+  capacityBase: bigint | number | string;
+}
+
+export interface CapacityForecastOptions {
+  /** Width of each historical bucket. */
+  windowMs: number;
+  /** Number of future windows to project. */
+  horizonWindows: number;
+  /** Optional growth buffer applied after trend projection. @default 0.15 */
+  safetyMargin?: number;
+}
+
+export interface ResourceForecast {
+  resource: ResourceType;
+  currentBase: bigint;
+  projectedBase: bigint;
+  recommendedCapacityBase: bigint;
+  utilization: number;
+  projectedUtilization: number;
+  trendPerWindowBase: bigint;
+  windowsObserved: number;
+  exhaustedAtWindow: number | null;
+  status: "healthy" | "watch" | "critical";
+}
+
+export interface CapacityPlan {
+  generatedAt: number;
+  windowMs: number;
+  horizonWindows: number;
+  forecasts: Record<ResourceType, ResourceForecast>;
+}
+
+function toBaseCapacity(value: bigint | number | string): bigint {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return BigInt(Math.trunc(value));
+  return BigInt(value);
+}
+
+function bucketReadings(readings: HistoricalReading[], windowMs: number) {
+  const buckets = new Map<number, HistoricalReading[]>();
+  for (const reading of readings) {
+    const windowStart = Math.floor(reading.timestamp / windowMs) * windowMs;
+    const bucket = buckets.get(windowStart);
+    if (bucket) bucket.push(reading);
+    else buckets.set(windowStart, [reading]);
+  }
+  return [...buckets.entries()].sort((a, b) => a[0] - b[0]);
+}
+
+function positiveTrend(values: bigint[]): bigint {
+  if (values.length < 2) return BigInt(0);
+  let totalIncrease = BigInt(0);
+  let samples = BigInt(0);
+  for (let i = 1; i < values.length; i++) {
+    const delta = values[i] - values[i - 1];
+    if (delta > BigInt(0)) totalIncrease += delta;
+    samples += BigInt(1);
+  }
+  return totalIncrease / samples;
+}
+
+function utilization(used: bigint, capacity: bigint): number {
+  if (capacity <= BigInt(0)) return used > BigInt(0) ? Infinity : 0;
+  return Number(used) / Number(capacity);
+}
+
+function applySafetyMargin(value: bigint, safetyMargin: number): bigint {
+  const basisPoints = BigInt(Math.ceil(safetyMargin * 10_000));
+  const denominator = BigInt(10_000);
+  return value + (value * basisPoints + denominator - BigInt(1)) / denominator;
+}
+
+function statusFor(projectedUtilization: number): ResourceForecast["status"] {
+  if (projectedUtilization >= 0.95) return "critical";
+  if (projectedUtilization >= 0.8) return "watch";
+  return "healthy";
+}
+
+/**
+ * Build a deterministic capacity plan from historical readings.
+ *
+ * The hot path is O(readings + resources × windows) and reuses the exact BigInt
+ * aggregation pipeline so trends cannot drift as history grows.
+ */
+export function planCapacity(
+  readings: HistoricalReading[],
+  limits: CapacityLimit[],
+  options: CapacityForecastOptions
+): CapacityPlan {
+  if (options.windowMs <= 0) throw new Error("windowMs must be positive");
+  if (options.horizonWindows < 0) throw new Error("horizonWindows cannot be negative");
+
+  const safetyMargin = options.safetyMargin ?? 0.15;
+  if (safetyMargin < 0) throw new Error("safetyMargin cannot be negative");
+
+  const capacityByResource = new Map(
+    limits.map((limit) => [limit.resource, toBaseCapacity(limit.capacityBase)] as const)
+  );
+  const buckets = bucketReadings(readings, options.windowMs);
+  const forecasts = {} as Record<ResourceType, ResourceForecast>;
+
+  for (const resource of RESOURCE_TYPES) {
+    const series = buckets.map(([, bucket]) =>
+      aggregateReadings(bucket.filter((reading) => reading.resource === resource), {
+        logger: { warn: () => {} },
+      }).byResource[resource]
+    );
+    const currentBase = series.at(-1) ?? BigInt(0);
+    const trendPerWindowBase = positiveTrend(series);
+    const projectedBase = currentBase + trendPerWindowBase * BigInt(options.horizonWindows);
+    const recommendedCapacityBase = applySafetyMargin(projectedBase, safetyMargin);
+    const capacityBase = capacityByResource.get(resource) ?? recommendedCapacityBase;
+    const projectedUtilization = utilization(projectedBase, capacityBase);
+    const exhaustedAtWindow =
+      trendPerWindowBase > BigInt(0) && currentBase < capacityBase
+        ? Number((capacityBase - currentBase + trendPerWindowBase - BigInt(1)) / trendPerWindowBase)
+        : currentBase >= capacityBase
+          ? 0
+          : null;
+
+    forecasts[resource] = {
+      resource,
+      currentBase,
+      projectedBase,
+      recommendedCapacityBase,
+      utilization: utilization(currentBase, capacityBase),
+      projectedUtilization,
+      trendPerWindowBase,
+      windowsObserved: series.length,
+      exhaustedAtWindow,
+      status: statusFor(projectedUtilization),
+    };
+  }
+
+  return {
+    generatedAt: Date.now(),
+    windowMs: options.windowMs,
+    horizonWindows: options.horizonWindows,
+    forecasts,
+  };
+}

--- a/tests/unit/capacityPlanning.test.ts
+++ b/tests/unit/capacityPlanning.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { planCapacity, type HistoricalReading } from "@/utils/capacityPlanning";
+
+describe("planCapacity", () => {
+  it("projects historical growth and recommends margin-adjusted capacity", () => {
+    vi.setSystemTime(new Date("2026-07-18T00:00:00Z"));
+    const hour = 60 * 60 * 1000;
+    const readings: HistoricalReading[] = [
+      { resource: "water", value: 10, timestamp: 0 },
+      { resource: "water", value: 20, timestamp: hour },
+      { resource: "water", value: 40, timestamp: 2 * hour },
+    ];
+
+    const plan = planCapacity(
+      readings,
+      [{ resource: "water", capacityBase: 85_000 }],
+      { windowMs: hour, horizonWindows: 2, safetyMargin: 0.1 }
+    );
+
+    expect(plan.generatedAt).toBe(Date.parse("2026-07-18T00:00:00Z"));
+    expect(plan.forecasts.water.currentBase).toBe(BigInt(40_000));
+    expect(plan.forecasts.water.trendPerWindowBase).toBe(BigInt(15_000));
+    expect(plan.forecasts.water.projectedBase).toBe(BigInt(70_000));
+    expect(plan.forecasts.water.recommendedCapacityBase).toBe(BigInt(77_000));
+    expect(plan.forecasts.water.status).toBe("watch");
+    vi.useRealTimers();
+  });
+
+  it("marks exhausted resources critical immediately", () => {
+    const plan = planCapacity(
+      [{ resource: "energy", value: 2, timestamp: 0 }],
+      [{ resource: "energy", capacityBase: 1 }],
+      { windowMs: 1000, horizonWindows: 1 }
+    );
+
+    expect(plan.forecasts.energy.exhaustedAtWindow).toBe(0);
+    expect(plan.forecasts.energy.status).toBe("critical");
+  });
+
+  it("validates planning bounds", () => {
+    expect(() =>
+      planCapacity([], [], { windowMs: 0, horizonWindows: 1 })
+    ).toThrow("windowMs must be positive");
+    expect(() =>
+      planCapacity([], [], { windowMs: 1, horizonWindows: -1 })
+    ).toThrow("horizonWindows cannot be negative");
+  });
+});


### PR DESCRIPTION
Motivation
Provide a deterministic, system-wide capacity planning primitive that projects usage from historical meter readings and recommends margin-adjusted capacity so operators can plan for growth and avoid outages.
Reuse the existing exact BigInt aggregation pipeline to avoid cumulative floating-point drift in trends and totals.
Surface actionable signals (utilization, trend, exhaustion window, status) and an operational runbook to support blue-green/canary deploys and alerting.
Description
Add a pure TypeScript planner at src/utils/capacityPlanning.ts that buckets historical readings, computes a positive-growth trend per window, projects future base-unit usage, applies a configurable safety margin (integer math), and emits per-resource forecasts and status (healthy|watch|critical).
Introduce docs/capacity-planning.md documenting architecture, operational targets, monitoring signals, alerts, and a runbook.
Add unit tests at tests/unit/capacityPlanning.test.ts covering growth projection, margin recommendation, exhausted capacity detection, and validation of planning bounds.
Testing
Ran the targeted unit tests with npm test -- tests/unit/capacityPlanning.test.ts, which passed (3 tests).
Type-checking with npx tsc --noEmit succeeded.
A full CI/local npm test and npm run lint run surfaced existing unrelated pre-existing failures and lint errors (failing tests in tests/components/AssetHeatmapLayer.test.tsx and tests/unit/keyCache.test.ts, and eslint errors in src/components/map/AssetHeatmapLayer.tsx), which are outside the changes in this PR.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/134