### PR TITLE
Code coverage threshold

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -36,9 +36,32 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  unit-coverage:
+    name: Unit Tests & Coverage
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - name: Install Vitest coverage provider
+        run: npm install --no-save @vitest/coverage-v8@4.1.9
+      - name: Run unit coverage gate
+        run: npm run test:coverage:ci
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: coverage/
+          retention-days: 30
+
   test:
     name: E2E Tests
-    needs: build
+    needs: [build, unit-coverage]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/coverage-ci.md
+++ b/docs/coverage-ci.md
@@ -1,0 +1,46 @@
+# CI code coverage gate
+
+The frontend CI pipeline enforces unit-test coverage before end-to-end tests run. The gate is implemented with Vitest's V8 coverage provider and is configured in `vitest.config.ts`.
+
+## Architecture
+
+1. GitHub Actions installs project dependencies with `npm ci`.
+2. The coverage job installs the matching Vitest V8 coverage provider for the pinned Vitest version.
+3. `npm run test:coverage:ci` runs the Vitest unit suite with coverage enabled.
+4. Vitest fails the job when global coverage drops below the configured thresholds.
+5. CI uploads `coverage/` as a build artifact so reviewers can inspect the text, JSON summary, and LCOV output.
+
+The coverage job depends on lint/type-checking and the E2E job depends on both the build and coverage jobs. This makes coverage a required quality gate while preserving existing build and browser-test coverage.
+
+## Thresholds
+
+Global coverage thresholds are:
+
+| Metric | Minimum |
+| --- | ---: |
+| Lines | 80% |
+| Statements | 80% |
+| Functions | 80% |
+| Branches | 70% |
+
+Worker entry points and locale JSON files are excluded from the aggregate because they are either exercised through integration paths or static data. Application TypeScript and TSX files under `src/` are included by default.
+
+## Runbook
+
+Run the same gate locally with:
+
+```bash
+npm install --no-save @vitest/coverage-v8@4.1.9
+npm run test:coverage:ci
+```
+
+If the job fails:
+
+1. Open the `coverage-reports` artifact from the failed workflow run.
+2. Review `coverage/coverage-summary.json` for the metric below threshold.
+3. Add or update unit tests for the uncovered paths.
+4. Re-run `npm run test:coverage:ci` before pushing.
+
+## Monitoring and alerts
+
+GitHub branch protection should mark `Frontend CI / Unit Tests & Coverage` as a required status check. Failed threshold checks surface as pull-request status failures, and the uploaded coverage artifact provides the dashboard for the run-level coverage breakdown.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:visual": "npx playwright test tests/visual",
-    "visual:update-baselines": "npx tsx scripts/update-baselines.ts"
+    "visual:update-baselines": "npx tsx scripts/update-baselines.ts",
+    "test:coverage": "vitest --run --coverage.enabled --coverage.provider=v8",
+    "test:coverage:ci": "vitest --run --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^15.1.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,26 @@ export default defineConfig({
     globals: true,
     setupFiles: './tests/setup.ts',
     include: ['tests/**/*.test.{ts,tsx}', 'src/tests/**/*.bench.{ts,tsx}'],
-    exclude: ['tests/e2e/**/*', 'node_modules/**/*'],
+    exclude: ['tests/e2e/**/*', 'tests/visual/**/*', 'node_modules/**/*'],
+    coverage: {
+      provider: 'v8',
+      enabled: false,
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/app/favicon.ico',
+        'src/i18n/locales/**/*.json',
+        'src/**/*.worker.ts',
+      ],
+      reporter: ['text', 'json-summary', 'lcov'],
+      reportsDirectory: './coverage',
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 70,
+        statements: 80,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Motivation
Enforce a global unit-test coverage quality gate in the frontend pipeline so regressions are caught before E2E/browser tests run.
Provide reproducible local and CI coverage runs with Vitest's V8 provider and a documented runbook for contributors and reviewers.
Description
Add test:coverage and test:coverage:ci scripts to package.json that run Vitest with V8 coverage and standard reporters (text, json-summary, lcov).
Update vitest.config.ts to configure coverage (provider v8, include/exclude patterns, reporters, ./coverage output, and global thresholds: lines/statements/functions 80% and branches 70%).
Add a unit-coverage job to .github/workflows/frontend-ci.yml that installs the matching @vitest/coverage-v8 provider, runs the coverage gate, uploads coverage/ as an artifact, and makes E2E tests depend on the coverage job.
Add docs/coverage-ci.md documenting the architecture, thresholds, runbook, and monitoring/branch-protection guidance.
Testing
npx tsc --noEmit passed against the updated TypeScript configuration.
npm run lint was executed and failed due to pre-existing unused-variable lint errors in src/components/map/AssetHeatmapLayer.tsx.
npm run test executed the unit test suite and reported most tests passing while leaving 3 failing tests (failures originate from existing test expectations and a crypto.subtle.digest usage in src/services/keyCache.ts).
npm run test:coverage:ci could not be run in this environment because installing @vitest/coverage-v8@4.1.9 from the npm registry is blocked by the environment (install attempts returned 403 Forbidden).
Closes https://github.com/Utility-Protocol/utility-frontend/issues/130