### PR TITLE
GitHub actions workflow

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -6,53 +6,115 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: frontend-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: 20
 
 jobs:
-  lint-and-typecheck:
-    name: Lint & TypeScript Check
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
-      - run: npm ci
-      - run: npm run lint
-      - run: npx tsc --noEmit
+      - name: Install dependencies
+        run: npm ci
+      - name: Run ESLint
+        run: npm run lint
+
+  typecheck:
+    name: TypeScript Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run TypeScript compiler
+        run: npx tsc --noEmit
+
+  unit-tests:
+    name: Unit & Component Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Vitest suite
+        run: npm run test
 
   build:
     name: Build
-    needs: lint-and-typecheck
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
-      - run: npm ci
-      - run: npm run build
+      - name: Install dependencies
+        run: npm ci
+      - name: Build application
+        run: npm run build
 
-  test:
-    name: E2E Tests
-    needs: build
+  e2e-tests:
+    name: E2E Tests (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/2, 2/2]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
-      - run: npm ci
+      - name: Install dependencies
+        run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
       - name: Start dev server
         run: npm run dev & npx wait-on http://localhost:3000
+        env:
+          CI: true
       - name: Run Playwright tests
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shard }}
       - name: Stop dev server
         if: always()
         run: kill $(lsof -t -i:3000) 2>/dev/null || true
+
+  ci-complete:
+    name: Frontend CI Complete
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, unit-tests, build, e2e-tests]
+    if: always()
+    steps:
+      - name: Check required jobs
+        run: |
+          if [[ '${{ contains(needs.*.result, 'failure') }}' == 'true' || '${{ contains(needs.*.result, 'cancelled') }}' == 'true' ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required frontend CI jobs passed."

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -8,6 +8,14 @@ on:
       - "tests/visual/**"
       - ".github/workflows/visual-regression.yml"
 
+concurrency:
+  group: visual-regression-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   NODE_VERSION: 20
 
@@ -15,6 +23,7 @@ jobs:
   visual-regression:
     name: Visual Regression Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +51,7 @@ jobs:
 
       - name: Run visual regression tests
         id: visual
-        run: npx playwright test --config=playwright.visual.config.ts
+        run: npx playwright test --config=playwright.visual.config.ts --workers=50%
         continue-on-error: true
 
       - name: Generate visual report

--- a/src/components/map/AssetHeatmapLayer.tsx
+++ b/src/components/map/AssetHeatmapLayer.tsx
@@ -1,7 +1,6 @@
-﻿'use client';
+'use client';
 
 import { useEffect, useRef } from 'react';
-import { getTile } from './heatmapStore';
 import { updateBoundary, getAffectedTiles } from './boundaryManager';
 
 interface AssetPosition {
@@ -41,11 +40,12 @@ export function AssetHeatmapLayer({ assets, boundaries, onTileUpdate }: HeatmapP
               heatValues[ty * 256 + tx] += asset.value;
             }
           }
+          onTileUpdate?.(_tileKey, heatValues);
           return heatValues;
         },
       });
     }
-  }, [assets, boundaries]);
+  }, [assets, boundaries, onTileUpdate]);
 
   return <canvas ref={canvasRef} width={800} height={600} />;
 }

--- a/src/components/map/boundaryManager.ts
+++ b/src/components/map/boundaryManager.ts
@@ -1,4 +1,4 @@
-﻿import { acquireTileLock, writeTile, getTileGeneration } from './heatmapStore';
+import { acquireTileLock, writeTile, getTileGeneration } from './heatmapStore';
 
 interface Boundary {
   id: string;
@@ -45,7 +45,7 @@ export function getAffectedTiles(
 
   for (let x = startX; x <= endX; x++) {
     for (let y = startY; y <= endY; y++) {
-      tiles.push(layer + '::' + x + ',' + y);
+      tiles.push(layer + ':' + x + ':' + y);
     }
   }
   return tiles;

--- a/src/services/keyCache.ts
+++ b/src/services/keyCache.ts
@@ -85,7 +85,8 @@ async function getDb(): Promise<IDBPDatabase> {
 
 /** Lowercase hex SHA-256 of the given bytes using SubtleCrypto. */
 export async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const normalizedBytes = new Uint8Array(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", normalizedBytes);
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");


### PR DESCRIPTION
Motivation
Reduce CI runtime and wasted runner time by parallelizing frontend checks and sharding long-running tests.
Harden workflows with concurrency cancellation, least-privilege permissions and job timeouts to improve CI reliability.
Fix existing lint/test regressions that prevented a green CI run.
Description
Split .github/workflows/frontend-ci.yml into independent lint, typecheck, unit-tests, build, and sharded e2e-tests jobs, added a ci-complete aggregation job, plus concurrency, job timeout-minutes, and permissions settings.
Touched .github/workflows/visual-regression.yml to add concurrency, explicit permissions, a timeout-minutes, and limited Playwright workers with --workers=50%.
Fixed heatmap wiring in src/components/map/AssetHeatmapLayer.tsx by calling the onTileUpdate callback and adding it to the effect dependency list, and removed an unused import.
Normalized tile key formatting in src/components/map/boundaryManager.ts from layer::x,y to layer:x:y.
Fixed sha256Hex in src/services/keyCache.ts by normalizing input bytes (new Uint8Array(bytes)) before calling crypto.subtle.digest to avoid runtime errors in tests.
Testing
Parsed workflows with Ruby/YAML to validate outputs via ruby -e "require 'yaml'; Dir['.github/workflows/*.yml'].each { |f| YAML.load_file(f); puts \"parsed #{f}\" }" which succeeded.
Ran static checks: npm run lint and npx tsc --noEmit, both succeeded after fixes.
Ran unit/component and integration tests with npm run test, all tests passed (547 tests passed).
Attempted npm run build but the Next.js production build failed in this environment due to inability to fetch Google Fonts from fonts.googleapis.com, so build steps should be re-run in CI or an environment with network access to Google Fonts.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/128