### PR TITLE
Docker image layer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Dependencies are installed inside Docker for reproducible, cacheable layers.
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Next.js build outputs and caches.
+.next
+out
+
+# Test and local artifacts.
+coverage
+playwright-report
+test-results
+tests/visual/diffs
+tests/visual/results
+visual-report.html
+visual-summary.json
+
+# VCS and editor metadata.
+.git
+.gitignore
+.github
+.vscode
+.idea
+
+# Environment files must be provided by the runtime platform.
+.env
+.env.*
+!.env.example
+
+# Documentation and status reports are not needed in the runtime image.
+README.md
+CLAUDE.md
+FINAL_STATUS.md
+IMPLEMENTATION_SUMMARY.md
+TEST_RESULTS.md
+VERIFICATION_REPORT.md

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   NODE_VERSION: 20
+  DOCKER_IMAGE_NAME: utility-frontend
 
 jobs:
   lint-and-typecheck:
@@ -34,7 +35,51 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**', 'public/**', 'next.config.*', 'tsconfig.json', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
       - run: npm run build
+
+  docker-image:
+    name: Docker Image
+    needs: lint-and-typecheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ env.DOCKER_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-
+
+      - name: Build Docker image with layer cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.DOCKER_IMAGE_NAME }}
+          cache-to: type=gha,scope=${{ env.DOCKER_IMAGE_NAME }},mode=max
+          build-args: |
+            NODE_VERSION=${{ env.NODE_VERSION }}
 
   test:
     name: E2E Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.7
+
+ARG NODE_VERSION=20
+
+FROM node:${NODE_VERSION}-bookworm-slim AS base
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+
+FROM base AS deps
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN --mount=type=cache,target=/app/.next/cache \
+    npm run build
+
+FROM node:${NODE_VERSION}-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN groupadd --system --gid 1001 nodejs \
+    && useradd --system --uid 1001 --gid nodejs nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/docs/runbooks/docker-ci-layer-caching.md
+++ b/docs/runbooks/docker-ci-layer-caching.md
@@ -1,0 +1,33 @@
+# Docker CI layer caching runbook
+
+## Architecture
+
+The frontend container build is split into deterministic stages so GitHub Actions can reuse expensive layers across pull requests and pushes:
+
+1. `deps` copies only `package.json` and `package-lock.json`, then runs `npm ci` with a BuildKit npm cache mount.
+2. `builder` reuses `deps`, copies application source, and runs `npm run build` with a BuildKit cache mount for `.next/cache`.
+3. `runner` copies only the Next.js standalone server, static assets, and `public/` files into a non-root production image.
+
+The `docker-image` CI job uses `docker/build-push-action` with the GitHub Actions cache backend (`type=gha`) and a stable `utility-frontend` scope. The job builds but does not push images, which validates the production Docker path without publishing unreviewed artifacts from pull requests.
+
+## Monitoring and alerting
+
+Review these signals on every CI run:
+
+- Docker build duration: compare the `Build Docker image with layer cache` step duration against recent successful runs.
+- Cache reuse: expand the Buildx logs and confirm dependency/build layers are restored instead of rebuilt after lockfile-stable changes.
+- Next.js build cache: check the `Restore Next.js build cache` step in the `Build` job for cache hits on source-only changes.
+- Security posture: verify the final image keeps `NODE_ENV=production`, disables Next telemetry, and runs as the unprivileged `nextjs` user.
+
+Alert the owning team if Docker build duration regresses by more than 50% for three consecutive runs, if cache restore fails across both `main` and pull-request builds, or if the build starts pushing images from pull-request events.
+
+## Deployment guidance
+
+Use the image produced from `main` as a blue-green candidate in the deployment platform. Promote it through a canary window before full traffic cutover, watching application latency, error rate, and container restart count. Roll back to the previous green image if any critical path exceeds the service SLO or if availability drops below target.
+
+## Troubleshooting
+
+- If dependency layers rebuild unexpectedly, check whether `package-lock.json` changed.
+- If source layers rebuild but dependencies are reused, this is expected for application code changes.
+- If Next.js standalone files are missing, confirm `next.config.ts` still sets `output: "standalone"`.
+- If cache storage fills up, adjust the Buildx cache `scope` or prune old GitHub Actions caches from repository settings.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:visual": "npx playwright test tests/visual",
-    "visual:update-baselines": "npx tsx scripts/update-baselines.ts"
+    "visual:update-baselines": "npx tsx scripts/update-baselines.ts",
+    "docker:build": "docker build -t utility-frontend .",
+    "docker:build:plain": "docker build --progress=plain -t utility-frontend ."
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^15.1.0",


### PR DESCRIPTION
Motivation
Reduce CI build time by reusing Docker and Next.js build layers across runs to improve developer feedback loops and lower resource usage.
Produce a minimal, non-root runtime image by leveraging Next.js standalone output so the runtime stage only contains required artifacts.
Document the caching architecture and operational runbook so teams can monitor cache reuse and troubleshoot build regressions.
Description
Add a multi-stage Dockerfile that uses BuildKit cache mounts for the npm cache and .next/cache, and produces a small non-root runner image from Next.js output: "standalone" (see next.config.ts).
Add a .dockerignore to keep dependencies, build outputs, test artifacts, VCS metadata, env files, and docs out of the build context.
Extend the Frontend CI workflow to restore the Next.js build cache with actions/cache@v4 and add a docker-image job that builds with docker/build-push-action@v6 using GitHub Actions layer cache (type=gha) with cache-from/cache-to configured.
Add helper npm scripts docker:build and docker:build:plain for local parity with the CI build process and add a runbook under docs/runbooks/docker-ci-layer-caching.md describing architecture, monitoring, deployment guidance, and troubleshooting.
Testing
npx tsc --noEmit completed successfully.
npm run lint failed due to pre-existing unused-variable lint errors in src/components/map/AssetHeatmapLayer.tsx (existing code issue, not introduced by these CI/Docker changes).
npm test (vitest --run) failed with 3 pre-existing test failures in tests/components/AssetHeatmapLayer.test.tsx and tests/unit/keyCache.test.ts (failures unrelated to Docker/CI additions).
npm run build (Next.js build) failed in this environment because the build could not fetch Google-hosted fonts, and docker build could not be executed here because Docker is not available in the execution environment.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/127