### PR TITLE
Blueprint for chaos engineering

### DIFF
--- a/docs/runbooks/chaos-engineering-staging.md
+++ b/docs/runbooks/chaos-engineering-staging.md
@@ -1,0 +1,51 @@
+# Chaos Engineering Testing Blueprint for Staging
+
+## Objectives and bounds
+
+This blueprint defines staged chaos experiments across the frontend, API gateway, telemetry stream, wallet adapter, and background workers. The staging chaos program must preserve these bounds:
+
+- Critical-path performance: P99 latency stays below 100 ms.
+- Availability: staging service availability remains at or above 99.99% during experiments.
+- Security: every experiment requires security review before enablement and is aborted immediately for any confirmed security finding.
+- Blast radius: each experiment starts at 1% canary traffic and must not exceed 10% of staging traffic until post-experiment review approves expansion.
+
+## Architecture
+
+1. Fault injection is applied through staging-only controls: edge latency rules, service mesh network policies, dependency route overrides, and worker resource limits.
+2. Experiment definitions live in `src/utils/chaosBlueprint.ts` so tests can enforce the same safety gates documented here.
+3. SLO monitors compare live telemetry against steady-state hypotheses before, during, and after each run.
+4. An abort controller disables the active fault, shifts traffic to blue, and pages the staging incident lead when any abort condition is met.
+
+## Experiment catalog
+
+| Experiment | Services | Fault | Success hypothesis | Primary rollback |
+| --- | --- | --- | --- | --- |
+| Frontend critical-path latency injection | Frontend, API gateway | Inject edge latency on 5% of staging traffic | Critical journeys remain below 100 ms P99 | Disable edge fault and shift traffic back to blue |
+| Telemetry stream network partition | Telemetry stream, background workers | Partition producers from consumers | Buffered telemetry drains after recovery while availability remains at 99.99% | Remove partition and scale consumers |
+| Wallet adapter dependency outage | Wallet adapter, API gateway | Route wallet dependency calls to controlled failures | Wallet flows fail closed with recovery messaging and no credential leakage | Restore route, rotate staging secrets if exposed, invalidate sessions |
+
+## Monitoring, alerting, and dashboards
+
+Dashboards must include these panels before the first run:
+
+- Web vitals and API gateway P99 latency with a 100 ms redline.
+- Staging availability and synthetic journey success rate with a 99.99% redline.
+- Error rate, queue depth, telemetry lag, worker replay success, wallet authentication failures, and session errors.
+- Security scanner alerts and secret exposure findings.
+
+Alerts page the staging incident lead when any abort condition in `STAGING_CHAOS_BLUEPRINT` is breached for its configured duration.
+
+## Deployment and canary analysis
+
+Use blue-green deployment for the chaos controls. Enable faults only on the green stack, then progress canary traffic through 1%, 5%, 25%, 50%, and 100% after each 15-minute analysis window passes. Roll back to blue immediately if latency, availability, error-rate, or security gates fail.
+
+## Runbook
+
+1. Confirm security approval, experiment owner, rollback owner, and incident lead.
+2. Verify dashboards are live and baseline metrics have been stable for at least 30 minutes.
+3. Deploy fault controls to green with the fault disabled.
+4. Shift 1% of staging traffic to green and enable the selected fault.
+5. Watch the analysis window; abort on any configured condition.
+6. Progress canary only after SLOs, synthetic checks, and security signals remain healthy.
+7. Disable the fault, return traffic to blue, and verify recovery metrics.
+8. Document results, customer-impact simulation, remediation items, and the next safe blast radius.

--- a/src/utils/chaosBlueprint.ts
+++ b/src/utils/chaosBlueprint.ts
@@ -1,0 +1,153 @@
+export type ChaosExperimentType =
+  | "latency"
+  | "network-partition"
+  | "dependency-failure"
+  | "resource-pressure"
+  | "restart";
+
+export type ChaosService =
+  | "frontend"
+  | "api-gateway"
+  | "telemetry-stream"
+  | "wallet-adapter"
+  | "background-workers";
+
+export interface ChaosSteadyState {
+  p99LatencyMs: number;
+  availabilityPercent: number;
+  errorRatePercent: number;
+}
+
+export interface ChaosAbortCondition {
+  metric: keyof ChaosSteadyState | "securityFinding";
+  operator: ">" | ">=" | "<" | "<=" | "=";
+  threshold: number | boolean;
+  durationSeconds: number;
+}
+
+export interface ChaosExperiment {
+  id: string;
+  name: string;
+  type: ChaosExperimentType;
+  services: ChaosService[];
+  hypothesis: string;
+  blastRadiusPercent: number;
+  durationMinutes: number;
+  steadyState: ChaosSteadyState;
+  abortConditions: ChaosAbortCondition[];
+  rollback: string[];
+  securityReviewRequired: boolean;
+  monitoringSignals: string[];
+}
+
+export interface ChaosBlueprint {
+  environment: "staging";
+  p99TargetMs: number;
+  availabilityTargetPercent: number;
+  experiments: ChaosExperiment[];
+  deploymentStrategy: {
+    mode: "blue-green-with-canary";
+    canaryPercentages: number[];
+    analysisWindowMinutes: number;
+  };
+}
+
+export const STAGING_CHAOS_BLUEPRINT: ChaosBlueprint = {
+  environment: "staging",
+  p99TargetMs: 100,
+  availabilityTargetPercent: 99.99,
+  deploymentStrategy: {
+    mode: "blue-green-with-canary",
+    canaryPercentages: [1, 5, 25, 50, 100],
+    analysisWindowMinutes: 15,
+  },
+  experiments: [
+    {
+      id: "frontend-latency-100ms",
+      name: "Frontend critical-path latency injection",
+      type: "latency",
+      services: ["frontend", "api-gateway"],
+      hypothesis:
+        "Critical user journeys remain below the 100 ms P99 budget while latency is injected at the edge.",
+      blastRadiusPercent: 5,
+      durationMinutes: 10,
+      steadyState: { p99LatencyMs: 100, availabilityPercent: 99.99, errorRatePercent: 0.1 },
+      abortConditions: [
+        { metric: "p99LatencyMs", operator: ">", threshold: 100, durationSeconds: 120 },
+        { metric: "availabilityPercent", operator: "<", threshold: 99.99, durationSeconds: 60 },
+        { metric: "securityFinding", operator: "=", threshold: true, durationSeconds: 0 },
+      ],
+      rollback: ["Disable edge latency fault", "Shift traffic back to blue", "Page staging incident lead"],
+      securityReviewRequired: true,
+      monitoringSignals: ["web_vitals_p99", "api_gateway_p99", "synthetic_checkout_success"],
+    },
+    {
+      id: "telemetry-stream-partition",
+      name: "Telemetry stream network partition",
+      type: "network-partition",
+      services: ["telemetry-stream", "background-workers"],
+      hypothesis:
+        "Buffered telemetry drains after partition recovery without dropping availability below target.",
+      blastRadiusPercent: 10,
+      durationMinutes: 15,
+      steadyState: { p99LatencyMs: 100, availabilityPercent: 99.99, errorRatePercent: 0.2 },
+      abortConditions: [
+        { metric: "availabilityPercent", operator: "<", threshold: 99.99, durationSeconds: 60 },
+        { metric: "errorRatePercent", operator: ">=", threshold: 1, durationSeconds: 120 },
+      ],
+      rollback: ["Remove partition rule", "Scale telemetry consumers", "Replay staging queue"],
+      securityReviewRequired: true,
+      monitoringSignals: ["telemetry_lag_seconds", "queue_depth", "worker_replay_success"],
+    },
+    {
+      id: "wallet-adapter-dependency-failure",
+      name: "Wallet adapter dependency outage",
+      type: "dependency-failure",
+      services: ["wallet-adapter", "api-gateway"],
+      hypothesis:
+        "Wallet flows fail closed with user-visible recovery messaging and no leaked credentials.",
+      blastRadiusPercent: 5,
+      durationMinutes: 10,
+      steadyState: { p99LatencyMs: 100, availabilityPercent: 99.99, errorRatePercent: 0.1 },
+      abortConditions: [
+        { metric: "securityFinding", operator: "=", threshold: true, durationSeconds: 0 },
+        { metric: "errorRatePercent", operator: ">=", threshold: 1, durationSeconds: 60 },
+      ],
+      rollback: ["Restore dependency route", "Rotate staging wallet secrets if exposed", "Invalidate sessions"],
+      securityReviewRequired: true,
+      monitoringSignals: ["wallet_auth_failures", "session_error_rate", "secret_scanner_alerts"],
+    },
+  ],
+};
+
+export function getExperimentsForService(service: ChaosService, blueprint = STAGING_CHAOS_BLUEPRINT) {
+  return blueprint.experiments.filter((experiment) => experiment.services.includes(service));
+}
+
+export function validateChaosBlueprint(blueprint: ChaosBlueprint): string[] {
+  const failures: string[] = [];
+
+  if (blueprint.p99TargetMs > 100) failures.push("Critical path P99 target must be <= 100 ms.");
+  if (blueprint.availabilityTargetPercent < 99.99) failures.push("Availability target must be at least 99.99%.");
+  if (blueprint.deploymentStrategy.mode !== "blue-green-with-canary") {
+    failures.push("Deployment strategy must be blue-green with canary analysis.");
+  }
+
+  for (const experiment of blueprint.experiments) {
+    if (!experiment.securityReviewRequired) failures.push(`${experiment.id} must require security review.`);
+    if (experiment.blastRadiusPercent <= 0 || experiment.blastRadiusPercent > 10) {
+      failures.push(`${experiment.id} blast radius must be between 1% and 10% for staging.`);
+    }
+    if (experiment.steadyState.p99LatencyMs > blueprint.p99TargetMs) {
+      failures.push(`${experiment.id} exceeds the blueprint P99 latency target.`);
+    }
+    if (experiment.steadyState.availabilityPercent < blueprint.availabilityTargetPercent) {
+      failures.push(`${experiment.id} falls below the blueprint availability target.`);
+    }
+    if (experiment.abortConditions.length === 0) failures.push(`${experiment.id} needs abort conditions.`);
+    if (experiment.rollback.length === 0) failures.push(`${experiment.id} needs rollback steps.`);
+    if (experiment.monitoringSignals.length < 3) failures.push(`${experiment.id} needs at least three monitoring signals.`);
+  }
+
+  return failures;
+}

--- a/tests/unit/chaosBlueprint.test.ts
+++ b/tests/unit/chaosBlueprint.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  STAGING_CHAOS_BLUEPRINT,
+  getExperimentsForService,
+  validateChaosBlueprint,
+  type ChaosBlueprint,
+} from "@/utils/chaosBlueprint";
+
+describe("staging chaos engineering blueprint", () => {
+  it("meets latency, availability, security, and rollout guardrails", () => {
+    expect(validateChaosBlueprint(STAGING_CHAOS_BLUEPRINT)).toEqual([]);
+  });
+
+  it("exposes service-specific experiments for orchestration", () => {
+    const walletExperiments = getExperimentsForService("wallet-adapter");
+
+    expect(walletExperiments).toHaveLength(1);
+    expect(walletExperiments[0]).toMatchObject({
+      id: "wallet-adapter-dependency-failure",
+      securityReviewRequired: true,
+    });
+  });
+
+  it("reports every safety violation with actionable messages", () => {
+    const unsafeBlueprint: ChaosBlueprint = {
+      ...STAGING_CHAOS_BLUEPRINT,
+      p99TargetMs: 150,
+      availabilityTargetPercent: 99.9,
+      deploymentStrategy: { ...STAGING_CHAOS_BLUEPRINT.deploymentStrategy, mode: "blue-green-with-canary" },
+      experiments: [
+        {
+          ...STAGING_CHAOS_BLUEPRINT.experiments[0],
+          securityReviewRequired: false,
+          blastRadiusPercent: 25,
+          steadyState: { p99LatencyMs: 200, availabilityPercent: 99, errorRatePercent: 0.1 },
+          abortConditions: [],
+          rollback: [],
+          monitoringSignals: ["web_vitals_p99"],
+        },
+      ],
+    };
+
+    expect(validateChaosBlueprint(unsafeBlueprint)).toEqual([
+      "Critical path P99 target must be <= 100 ms.",
+      "Availability target must be at least 99.99%.",
+      "frontend-latency-100ms must require security review.",
+      "frontend-latency-100ms blast radius must be between 1% and 10% for staging.",
+      "frontend-latency-100ms exceeds the blueprint P99 latency target.",
+      "frontend-latency-100ms falls below the blueprint availability target.",
+      "frontend-latency-100ms needs abort conditions.",
+      "frontend-latency-100ms needs rollback steps.",
+      "frontend-latency-100ms needs at least three monitoring signals.",
+    ]);
+  });
+});


### PR DESCRIPTION
Motivation
Provide a repeatable, typed blueprint for running Chaos Engineering experiments in the staging environment with explicit safety guardrails.
Ensure orchestration and SLO tooling can reference the same experiment definitions used by runbooks and tests.
Surface automated checks to prevent unsafe experiment configurations before faults are applied.
Description
Add a typed blueprint at src/utils/chaosBlueprint.ts containing STAGING_CHAOS_BLUEPRINT, experiment types, getExperimentsForService, and validateChaosBlueprint validation logic.
Add a runbook describing objectives, architecture, experiment catalog, monitoring/alerting, blue-green canary rollout, and rollback procedures at docs/runbooks/chaos-engineering-staging.md.
Add unit tests at tests/unit/chaosBlueprint.test.ts that validate the safe blueprint, service-specific experiment lookup, and reporting of actionable safety violations.
Testing
Ran the unit tests with npm test -- tests/unit/chaosBlueprint.test.ts, which executed 1 test file and all 3 tests passed.
Ran targeted linting with npx eslint src/utils/chaosBlueprint.ts tests/unit/chaosBlueprint.test.ts, which passed for the new files.
Ran TypeScript checks with npx tsc --noEmit, which passed.
Note: an earlier attempt using Jest-style --runInBand failed because Vitest does not accept that option, and running the repository-wide npm run lint surfaced unrelated pre-existing unused-variable errors in other files that are not part of these changes.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/124