### PR TITLE
Secret rotation service

### DIFF
--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -1,0 +1,36 @@
+# Secret Rotation Service Runbook
+
+## Architecture
+
+The frontend models secret rotation as metadata only: secret identifiers, versions,
+ownership, service-level telemetry, and promotion decisions. Secret values remain in
+server-side secret managers and must never be exposed through `NEXT_PUBLIC_` values or
+client components. This follows the Next.js data-security guidance that secrets belong
+in environment variables and server-side data access layers.
+
+## Rotation flow
+
+1. Detect due database credentials and API keys from their configured rotation interval.
+2. Create the next credential version while keeping the active version enabled.
+3. Enter dual-read/dual-write mode so clients can authenticate with both versions.
+4. Deploy green clients with blue-green routing and begin a 5% canary.
+5. Promote only when critical-path P99 latency is below 100 ms, availability is at least
+   99.99%, error rate is within budget, and canary success is at least 99.9%.
+6. Revoke the previous credential only after connection pools drain and audit evidence
+   has been attached to the security review.
+
+## Monitoring and alerts
+
+Dashboards should chart per-secret owner, active and next versions, milliseconds until
+rotation is due, P99 latency, availability percentage, error rate, and canary success
+rate. Alert when any promotion guardrail fails; failed canaries must freeze expansion,
+route traffic back to blue, and page the owning service plus security reviewers.
+
+## Deployment checklist
+
+- Security review approved for the credential scope and revocation plan.
+- Blue credential version remains available throughout the canary.
+- Green deployment starts at 5% traffic and expands only after automated guardrails pass.
+- Rollback keeps the previous credential enabled until all clients report recovery.
+- Post-rotation evidence records the promoted version, revoked version, timestamps, and
+  dashboard links.

--- a/src/services/secretRotation.ts
+++ b/src/services/secretRotation.ts
@@ -1,0 +1,114 @@
+export type SecretKind = "database" | "api-key";
+export type RotationPhase = "pending" | "dual-write" | "canary" | "promoted" | "rolled-back";
+
+export interface SecretDescriptor {
+  id: string;
+  kind: SecretKind;
+  ownerService: string;
+  activeVersion: string;
+  nextVersion?: string;
+  lastRotatedAt: number;
+  rotationIntervalMs: number;
+}
+
+export interface RotationTelemetry {
+  p99LatencyMs: number;
+  availabilityPercent: number;
+  errorRate: number;
+  canarySuccessRate: number;
+}
+
+export interface RotationPolicy {
+  maxCriticalPathP99Ms: number;
+  minAvailabilityPercent: number;
+  maxErrorRate: number;
+  minCanarySuccessRate: number;
+}
+
+export interface RotationDecision {
+  phase: RotationPhase;
+  shouldPromote: boolean;
+  alerts: string[];
+  runbookSteps: string[];
+}
+
+export const DEFAULT_ROTATION_POLICY: RotationPolicy = {
+  maxCriticalPathP99Ms: 100,
+  minAvailabilityPercent: 99.99,
+  maxErrorRate: 0.001,
+  minCanarySuccessRate: 0.999,
+};
+
+export function isRotationDue(secret: SecretDescriptor, now = Date.now()): boolean {
+  return now - secret.lastRotatedAt >= secret.rotationIntervalMs;
+}
+
+export function planSecretRotation(secret: SecretDescriptor, now = Date.now()): RotationDecision {
+  const due = isRotationDue(secret, now);
+  return {
+    phase: due ? "dual-write" : "pending",
+    shouldPromote: false,
+    alerts: due ? [`${secret.id} is due for rotation`] : [],
+    runbookSteps: due
+      ? [
+          "Create a new credential version in the secret manager without disabling the active version.",
+          "Enable dual-read/dual-write clients and verify both credential versions authenticate.",
+          "Start the blue-green rollout with a 5% canary before increasing traffic.",
+        ]
+      : ["No action required until the configured rotation interval elapses."],
+  };
+}
+
+export function evaluateCanary(
+  telemetry: RotationTelemetry,
+  policy: RotationPolicy = DEFAULT_ROTATION_POLICY
+): RotationDecision {
+  const alerts: string[] = [];
+
+  if (telemetry.p99LatencyMs >= policy.maxCriticalPathP99Ms) {
+    alerts.push(`P99 latency ${telemetry.p99LatencyMs}ms breaches ${policy.maxCriticalPathP99Ms}ms target`);
+  }
+  if (telemetry.availabilityPercent < policy.minAvailabilityPercent) {
+    alerts.push(`Availability ${telemetry.availabilityPercent}% is below ${policy.minAvailabilityPercent}% target`);
+  }
+  if (telemetry.errorRate > policy.maxErrorRate) {
+    alerts.push(`Error rate ${telemetry.errorRate} exceeds ${policy.maxErrorRate} budget`);
+  }
+  if (telemetry.canarySuccessRate < policy.minCanarySuccessRate) {
+    alerts.push(`Canary success rate ${telemetry.canarySuccessRate} is below ${policy.minCanarySuccessRate}`);
+  }
+
+  const shouldPromote = alerts.length === 0;
+
+  return {
+    phase: shouldPromote ? "promoted" : "rolled-back",
+    shouldPromote,
+    alerts,
+    runbookSteps: shouldPromote
+      ? [
+          "Promote the green secret version to active for all services.",
+          "Revoke the previous credential after connection pools have drained.",
+          "Record rotation evidence and security-review approval links.",
+        ]
+      : [
+          "Freeze canary expansion and route traffic back to the blue credential version.",
+          "Keep the previous credential enabled until all clients confirm recovery.",
+          "Page the owning service and security reviewers with canary telemetry.",
+        ],
+  };
+}
+
+export function buildRotationDashboardMetrics(secret: SecretDescriptor, telemetry: RotationTelemetry) {
+  return {
+    secretId: secret.id,
+    kind: secret.kind,
+    ownerService: secret.ownerService,
+    activeVersion: secret.activeVersion,
+    nextVersion: secret.nextVersion ?? null,
+    millisecondsUntilDue: Math.max(0, secret.lastRotatedAt + secret.rotationIntervalMs - Date.now()),
+    p99LatencyMs: telemetry.p99LatencyMs,
+    availabilityPercent: telemetry.availabilityPercent,
+    errorRate: telemetry.errorRate,
+    canarySuccessRate: telemetry.canarySuccessRate,
+  };
+}

--- a/tests/services/secretRotation.test.ts
+++ b/tests/services/secretRotation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ROTATION_POLICY,
+  buildRotationDashboardMetrics,
+  evaluateCanary,
+  isRotationDue,
+  planSecretRotation,
+  type SecretDescriptor,
+} from "@/services/secretRotation";
+
+const now = new Date("2026-07-18T00:00:00.000Z").getTime();
+const day = 24 * 60 * 60 * 1000;
+
+function secret(overrides: Partial<SecretDescriptor> = {}): SecretDescriptor {
+  return {
+    id: "prod/postgres/app",
+    kind: "database",
+    ownerService: "utility-api",
+    activeVersion: "v12",
+    nextVersion: "v13",
+    lastRotatedAt: now - 91 * day,
+    rotationIntervalMs: 90 * day,
+    ...overrides,
+  };
+}
+
+describe("secret rotation planning", () => {
+  it("detects due database and API key credentials", () => {
+    expect(isRotationDue(secret(), now)).toBe(true);
+    expect(isRotationDue(secret({ lastRotatedAt: now - 10 * day }), now)).toBe(false);
+  });
+
+  it("starts due secrets in dual-write with operator runbook steps", () => {
+    const decision = planSecretRotation(secret(), now);
+    expect(decision.phase).toBe("dual-write");
+    expect(decision.shouldPromote).toBe(false);
+    expect(decision.alerts).toContain("prod/postgres/app is due for rotation");
+    expect(decision.runbookSteps.join(" ")).toContain("blue-green");
+  });
+});
+
+describe("secret rotation canary guardrails", () => {
+  it("promotes only when latency, availability, error rate, and canary health pass", () => {
+    const decision = evaluateCanary({
+      p99LatencyMs: DEFAULT_ROTATION_POLICY.maxCriticalPathP99Ms - 1,
+      availabilityPercent: DEFAULT_ROTATION_POLICY.minAvailabilityPercent,
+      errorRate: DEFAULT_ROTATION_POLICY.maxErrorRate,
+      canarySuccessRate: DEFAULT_ROTATION_POLICY.minCanarySuccessRate,
+    });
+    expect(decision.phase).toBe("promoted");
+    expect(decision.shouldPromote).toBe(true);
+    expect(decision.alerts).toHaveLength(0);
+  });
+
+  it("rolls back and alerts on SLO or canary regression", () => {
+    const decision = evaluateCanary({
+      p99LatencyMs: 120,
+      availabilityPercent: 99.9,
+      errorRate: 0.01,
+      canarySuccessRate: 0.98,
+    });
+    expect(decision.phase).toBe("rolled-back");
+    expect(decision.shouldPromote).toBe(false);
+    expect(decision.alerts).toHaveLength(4);
+    expect(decision.runbookSteps.join(" ")).toContain("route traffic back");
+  });
+
+  it("emits dashboard-friendly metrics without secret material", () => {
+    const metrics = buildRotationDashboardMetrics(secret(), {
+      p99LatencyMs: 42,
+      availabilityPercent: 100,
+      errorRate: 0,
+      canarySuccessRate: 1,
+    });
+    expect(metrics).toMatchObject({
+      secretId: "prod/postgres/app",
+      ownerService: "utility-api",
+      activeVersion: "v12",
+      nextVersion: "v13",
+      p99LatencyMs: 42,
+    });
+    expect(JSON.stringify(metrics)).not.toContain("password");
+  });
+});


### PR DESCRIPTION
Motivation
Provide a frontend-side model and decisioning layer for rotating database credentials and API keys while keeping secret material server-side only.
Encode blue-green/canary guardrails and operator runbook steps so rotations respect SLOs and security review constraints.
Surface dashboard-friendly telemetry without exposing secret values in the client, following Next.js data-security guidance.
Description
Add a typed rotation service at src/services/secretRotation.ts that models SecretDescriptor, rotation policies, planSecretRotation, evaluateCanary, and buildRotationDashboardMetrics.
Include sensible defaults as DEFAULT_ROTATION_POLICY and helper isRotationDue to detect when rotations should start.
Add unit tests at tests/services/secretRotation.test.ts covering due detection, dual-write planning, canary promotion/rollback decisions, and dashboard-safe metrics.
Add an ops runbook docs/runbooks/secret-rotation.md describing architecture, rotation flow, monitoring, alerts, and deployment checklist.
Testing
Ran the service tests with npm test -- tests/services/secretRotation.test.ts, which passed (5 tests, 1 file).
Ran linter with npm run lint, which failed due to pre-existing unused-variable errors in src/components/map/AssetHeatmapLayer.tsx unrelated to these changes.
Ran the full test suite with npm test, which surfaced unrelated pre-existing failures in tests/components/AssetHeatmapLayer.test.tsx (2 failing cases) and tests/unit/keyCache.test.ts SHA-256 handling (1 failing case), while other tests passed.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/123