### PR TITLE
Database migration versioning

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,27 @@
+# Database migration versioning and rollback support
+
+## Architecture
+
+Use `MigrationRunner` for all service-owned schema changes. Each migration has a positive integer `version`, a stable `name`, an `up` function for deploys, and a `down` function for rollback. Runtime state is kept behind a `MigrationStore`, so services can persist the current version and append-only audit history in their own database metadata table, IndexedDB store, or control-plane API.
+
+The runner builds an ordered plan from the current version to the requested target. Forward deployments run `up` migrations in ascending version order. Rollbacks run `down` migrations in descending version order and move the stored version to `version - 1` after each successful step.
+
+## Operational controls
+
+- Critical paths should not run migrations inline with user requests. Execute migrations during deployment or service startup readiness gates so the <100ms P99 target for request handling remains protected.
+- Use blue-green deployments by migrating the green environment first, validating health checks, and shifting traffic only after the target version is confirmed.
+- Canary analysis should compare migration failure counts, migration duration, request latency, and error rate before expanding traffic.
+- Security review should validate every migration for least-privilege database permissions, reversible data handling, and safe treatment of secrets or personally identifiable information.
+
+## Monitoring and alerting
+
+`MigrationRunner` emits `db_migration_duration_ms` on success and `db_migration_failure` on failure when a `recordMetric` callback is supplied. Dashboards should show current schema version, latest migration status, duration by version, and failure counts by service. Alert on any migration failure or on migration duration exceeding the service's deployment SLO.
+
+## Runbook
+
+1. Confirm the currently stored version and the target version.
+2. Generate and review the migration plan before execution.
+3. Run `migrateTo(targetVersion)` in the green or canary environment.
+4. Verify health checks, dashboards, and service logs.
+5. If rollback is required, call `rollback(steps)` or `migrateTo(previousVersion)` and keep traffic on the healthy environment until validation passes.
+6. Preserve migration history records for audit and incident review.

--- a/src/utils/dbMigration.ts
+++ b/src/utils/dbMigration.ts
@@ -1,0 +1,178 @@
+export type MigrationDirection = "up" | "down";
+
+export interface MigrationContext {
+  recordMetric?: (name: string, value: number, tags?: Record<string, string>) => void;
+  logger?: Pick<Console, "info" | "warn" | "error">;
+}
+
+export interface DatabaseMigration {
+  version: number;
+  name: string;
+  up: (context: MigrationContext) => Promise<void> | void;
+  down: (context: MigrationContext) => Promise<void> | void;
+}
+
+export interface MigrationRecord {
+  version: number;
+  name: string;
+  direction: MigrationDirection;
+  status: "applied" | "rolled_back";
+  startedAt: number;
+  finishedAt: number;
+  durationMs: number;
+}
+
+export interface MigrationStore {
+  getCurrentVersion(): Promise<number> | number;
+  setCurrentVersion(version: number): Promise<void> | void;
+  appendHistory(record: MigrationRecord): Promise<void> | void;
+}
+
+export interface MigrationPlanStep {
+  migration: DatabaseMigration;
+  direction: MigrationDirection;
+}
+
+export class InMemoryMigrationStore implements MigrationStore {
+  private version: number;
+  readonly history: MigrationRecord[] = [];
+
+  constructor(initialVersion = 0) {
+    this.version = initialVersion;
+  }
+
+  getCurrentVersion(): number {
+    return this.version;
+  }
+
+  setCurrentVersion(version: number): void {
+    this.version = version;
+  }
+
+  appendHistory(record: MigrationRecord): void {
+    this.history.push(record);
+  }
+}
+
+export class MigrationError extends Error {
+  constructor(message: string, readonly version: number, readonly direction: MigrationDirection) {
+    super(message);
+    this.name = "MigrationError";
+  }
+}
+
+export function createMigrationPlan(
+  migrations: readonly DatabaseMigration[],
+  currentVersion: number,
+  targetVersion: number
+): MigrationPlanStep[] {
+  const registry = normalizeMigrations(migrations);
+  if (currentVersion === targetVersion) return [];
+
+  if (targetVersion > currentVersion) {
+    return Array.from(registry.values())
+      .filter((migration) => migration.version > currentVersion && migration.version <= targetVersion)
+      .map((migration) => ({ migration, direction: "up" as const }));
+  }
+
+  return Array.from(registry.values())
+    .filter((migration) => migration.version > targetVersion && migration.version <= currentVersion)
+    .sort((a, b) => b.version - a.version)
+    .map((migration) => ({ migration, direction: "down" as const }));
+}
+
+export class MigrationRunner {
+  private readonly migrations: readonly DatabaseMigration[];
+  private readonly store: MigrationStore;
+  private readonly context: MigrationContext;
+
+  constructor(options: {
+    migrations: readonly DatabaseMigration[];
+    store: MigrationStore;
+    context?: MigrationContext;
+  }) {
+    this.migrations = options.migrations;
+    this.store = options.store;
+    this.context = options.context ?? {};
+    normalizeMigrations(this.migrations);
+  }
+
+  async migrateTo(targetVersion: number): Promise<MigrationRecord[]> {
+    const currentVersion = await this.store.getCurrentVersion();
+    const plan = createMigrationPlan(this.migrations, currentVersion, targetVersion);
+    const records: MigrationRecord[] = [];
+
+    for (const step of plan) {
+      records.push(await this.runStep(step));
+    }
+
+    return records;
+  }
+
+  async rollback(steps = 1): Promise<MigrationRecord[]> {
+    if (!Number.isInteger(steps) || steps < 1) {
+      throw new RangeError("Rollback steps must be a positive integer.");
+    }
+
+    const currentVersion = await this.store.getCurrentVersion();
+    const targetVersion = Math.max(0, currentVersion - steps);
+    return this.migrateTo(targetVersion);
+  }
+
+  private async runStep({ migration, direction }: MigrationPlanStep): Promise<MigrationRecord> {
+    const startedAt = Date.now();
+    this.context.logger?.info?.(`[migration] ${direction} ${migration.version} ${migration.name}`);
+
+    try {
+      await migration[direction](this.context);
+    } catch (error) {
+      this.context.logger?.error?.(error);
+      this.context.recordMetric?.("db_migration_failure", 1, {
+        direction,
+        version: String(migration.version),
+      });
+      throw new MigrationError(
+        `Failed to run ${direction} migration ${migration.version}: ${migration.name}`,
+        migration.version,
+        direction
+      );
+    }
+
+    const finishedAt = Date.now();
+    const nextVersion = direction === "up" ? migration.version : migration.version - 1;
+    await this.store.setCurrentVersion(nextVersion);
+
+    const record: MigrationRecord = {
+      version: migration.version,
+      name: migration.name,
+      direction,
+      status: direction === "up" ? "applied" : "rolled_back",
+      startedAt,
+      finishedAt,
+      durationMs: finishedAt - startedAt,
+    };
+    await this.store.appendHistory(record);
+    this.context.recordMetric?.("db_migration_duration_ms", record.durationMs, {
+      direction,
+      version: String(migration.version),
+    });
+    return record;
+  }
+}
+
+function normalizeMigrations(migrations: readonly DatabaseMigration[]): Map<number, DatabaseMigration> {
+  const sorted = [...migrations].sort((a, b) => a.version - b.version);
+  const registry = new Map<number, DatabaseMigration>();
+
+  for (const migration of sorted) {
+    if (!Number.isInteger(migration.version) || migration.version < 1) {
+      throw new RangeError("Migration versions must be positive integers.");
+    }
+    if (registry.has(migration.version)) {
+      throw new RangeError(`Duplicate migration version: ${migration.version}.`);
+    }
+    registry.set(migration.version, migration);
+  }
+
+  return registry;
+}

--- a/tests/unit/dbMigration.test.ts
+++ b/tests/unit/dbMigration.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMigrationPlan,
+  InMemoryMigrationStore,
+  MigrationError,
+  MigrationRunner,
+  type DatabaseMigration,
+} from "@/utils/dbMigration";
+
+function migration(version: number, calls: string[]): DatabaseMigration {
+  return {
+    version,
+    name: `migration-${version}`,
+    up: () => {
+      calls.push(`up:${version}`);
+    },
+    down: () => {
+      calls.push(`down:${version}`);
+    },
+  };
+}
+
+describe("database migration versioning", () => {
+  it("plans forward migrations in ascending version order", () => {
+    const calls: string[] = [];
+    const plan = createMigrationPlan([migration(3, calls), migration(1, calls), migration(2, calls)], 1, 3);
+
+    expect(plan.map((step) => `${step.direction}:${step.migration.version}`)).toEqual(["up:2", "up:3"]);
+  });
+
+  it("plans rollback migrations in descending version order", () => {
+    const calls: string[] = [];
+    const plan = createMigrationPlan([migration(1, calls), migration(2, calls), migration(3, calls)], 3, 1);
+
+    expect(plan.map((step) => `${step.direction}:${step.migration.version}`)).toEqual(["down:3", "down:2"]);
+  });
+
+  it("applies migrations, persists version state, and emits metrics", async () => {
+    const calls: string[] = [];
+    const recordMetric = vi.fn();
+    const store = new InMemoryMigrationStore();
+    const runner = new MigrationRunner({
+      migrations: [migration(1, calls), migration(2, calls)],
+      store,
+      context: { recordMetric },
+    });
+
+    const records = await runner.migrateTo(2);
+
+    expect(calls).toEqual(["up:1", "up:2"]);
+    expect(store.getCurrentVersion()).toBe(2);
+    expect(records.map((record) => record.status)).toEqual(["applied", "applied"]);
+    expect(recordMetric).toHaveBeenCalledWith(
+      "db_migration_duration_ms",
+      expect.any(Number),
+      expect.objectContaining({ direction: "up", version: "1" })
+    );
+  });
+
+  it("rolls back the requested number of versions", async () => {
+    const calls: string[] = [];
+    const store = new InMemoryMigrationStore(3);
+    const runner = new MigrationRunner({
+      migrations: [migration(1, calls), migration(2, calls), migration(3, calls)],
+      store,
+    });
+
+    const records = await runner.rollback(2);
+
+    expect(calls).toEqual(["down:3", "down:2"]);
+    expect(store.getCurrentVersion()).toBe(1);
+    expect(records.map((record) => record.status)).toEqual(["rolled_back", "rolled_back"]);
+  });
+
+  it("stops and preserves the current version when a migration fails", async () => {
+    const store = new InMemoryMigrationStore(1);
+    const recordMetric = vi.fn();
+    const runner = new MigrationRunner({
+      migrations: [
+        migration(1, []),
+        {
+          version: 2,
+          name: "broken",
+          up: () => {
+            throw new Error("boom");
+          },
+          down: () => undefined,
+        },
+      ],
+      store,
+      context: { recordMetric },
+    });
+
+    await expect(runner.migrateTo(2)).rejects.toBeInstanceOf(MigrationError);
+    expect(store.getCurrentVersion()).toBe(1);
+    expect(recordMetric).toHaveBeenCalledWith(
+      "db_migration_failure",
+      1,
+      expect.objectContaining({ direction: "up", version: "2" })
+    );
+  });
+});


### PR DESCRIPTION
Motivation
Provide a system-wide, versioned migration framework that supports forward deployments and safe rollbacks, with audit history and metric hooks for monitoring.
Ensure services can persist schema version state behind an abstraction so migrations are portable across storage backends.
Meet operational constraints by documenting runbooks and deployment guidance for blue-green and canary strategies.
Description
Added a new migration module src/utils/dbMigration.ts that defines DatabaseMigration, MigrationStore, MigrationRunner, createMigrationPlan, normalizeMigrations, InMemoryMigrationStore, and a MigrationError type.
The runner builds ordered plans for up (ascending) and down (descending) execution, runs each step with error handling, updates the store, appends an audit record, and emits optional metrics via recordMetric hooks.
Added documentation docs/database-migrations.md describing architecture, operational controls, monitoring/alerting, and a rollback runbook.
Added unit tests tests/unit/dbMigration.test.ts covering planning, application, rollback sequencing, metric emission, and failure behavior.
Testing
Ran the targeted unit tests with npm test -- tests/unit/dbMigration.test.ts, which passed (1 test file, 5 tests passed).
Type-checked the repository with npx tsc --noEmit, which succeeded.
Ran npm run lint, which failed due to pre-existing unused-variable errors in src/components/map/AssetHeatmapLayer.tsx (unrelated to these changes).
Ran the full test suite with npm test, which surfaced unrelated pre-existing failures in tests/components/AssetHeatmapLayer.test.tsx and tests/unit/keyCache.test.ts and thus did not fully pass.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/122