### PR TITLE
Distributed job scheduler

### DIFF
--- a/docs/distributed-job-scheduler.md
+++ b/docs/distributed-job-scheduler.md
@@ -1,0 +1,23 @@
+# Distributed Job Scheduler Architecture
+
+The scheduler uses lease-based worker claiming so only one worker executes a job at a time while allowing automatic recovery if a worker crashes. Jobs are persisted with `queued`, `leased`, `completed`, or `failed` state, a due time, priority, attempt count, and lease owner metadata.
+
+## Critical path
+
+1. Producers enqueue a deterministic job id and payload.
+2. Workers poll their queue and atomically claim due jobs whose state is `queued` or whose lease has expired.
+3. A claimed job receives a lease owner and expiry. Workers must complete, fail, or renew before expiry.
+4. Expired leases are claimable by another worker; stale workers cannot complete or renew after expiry.
+5. Failed jobs are retried with backoff until `maxAttempts`, then moved to terminal `failed` state.
+
+## Production storage contract
+
+Back this interface with a datastore that supports conditional writes in a single partition/key transaction, for example `UPDATE ... WHERE status = queued OR lease_expires_at <= now`. Keep queue, due time, and priority indexed to preserve the sub-100 ms P99 claim path.
+
+## Monitoring and alerts
+
+Export `SchedulerMetrics` as counters/gauges: queued jobs, leased jobs, completed jobs, failed jobs, expired lease count, and claim latency. Alert when claim P99 exceeds 100 ms, failed jobs grow for 5 minutes, or expired leases spike above the canary baseline.
+
+## Blue-green and canary deployment
+
+Run green workers in shadow claim mode first, then canary 5% of queues by queue prefix or shard. Compare claim latency, duplicate execution guards, failure rate, and expired lease rate before shifting the remaining traffic.

--- a/docs/runbooks/distributed-job-scheduler.md
+++ b/docs/runbooks/distributed-job-scheduler.md
@@ -1,0 +1,20 @@
+# Distributed Job Scheduler Runbook
+
+## Symptoms
+
+- Queue depth increasing while workers are healthy.
+- Claim latency over 100 ms P99.
+- Expired leases or failed jobs increasing rapidly.
+
+## Triage
+
+1. Check scheduler dashboards for queued, leased, failed, expired lease, and claim latency metrics.
+2. Verify datastore conditional-write latency and error rate.
+3. Confirm workers renew leases before half the lease TTL elapses.
+4. Pause canary traffic if the green deployment has higher failures than blue.
+
+## Recovery
+
+- Scale workers for queue-depth pressure.
+- Increase lease TTL only if jobs are legitimately longer than the current TTL.
+- Requeue terminal failures only after confirming the handler is idempotent and the root cause is resolved.

--- a/src/services/distributedJobScheduler.ts
+++ b/src/services/distributedJobScheduler.ts
@@ -1,0 +1,194 @@
+export type DistributedJobStatus = "queued" | "leased" | "completed" | "failed";
+
+export interface DistributedJob<TPayload = unknown> {
+  id: string;
+  queue: string;
+  payload: TPayload;
+  runAt: number;
+  priority: number;
+  attempts: number;
+  maxAttempts: number;
+  status: DistributedJobStatus;
+  leaseOwner: string | null;
+  leaseExpiresAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+  lastError?: string;
+}
+
+export interface JobLease<TPayload = unknown> {
+  token: string;
+  workerId: string;
+  expiresAt: number;
+  job: DistributedJob<TPayload>;
+}
+
+export interface SchedulerMetrics {
+  queued: number;
+  leased: number;
+  completed: number;
+  failed: number;
+  expiredLeases: number;
+  claimLatencyMs: number;
+}
+
+export interface EnqueueJobOptions<TPayload> {
+  id: string;
+  queue?: string;
+  payload: TPayload;
+  runAt?: number;
+  priority?: number;
+  maxAttempts?: number;
+}
+
+export interface ClaimOptions {
+  workerId: string;
+  queue?: string;
+  leaseMs: number;
+  maxJobs?: number;
+  now?: number;
+}
+
+export interface CompleteOptions {
+  token: string;
+  workerId: string;
+  now?: number;
+}
+
+export interface FailOptions extends CompleteOptions {
+  error: string;
+  retryDelayMs?: number;
+}
+
+export class LeaseConflictError extends Error {
+  constructor(message = "job lease is no longer owned by this worker") {
+    super(message);
+    this.name = "LeaseConflictError";
+  }
+}
+
+const DEFAULT_QUEUE = "default";
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+function cloneJob<TPayload>(job: DistributedJob<TPayload>): DistributedJob<TPayload> {
+  return { ...job };
+}
+
+function isClaimable(job: DistributedJob, queue: string, now: number): boolean {
+  if (job.queue !== queue || job.runAt > now) return false;
+  if (job.status === "queued") return true;
+  return job.status === "leased" && (job.leaseExpiresAt ?? 0) <= now;
+}
+
+export class InMemoryDistributedJobScheduler<TPayload = unknown> {
+  private readonly jobs = new Map<string, DistributedJob<TPayload>>();
+  private readonly leaseTokens = new Map<string, string>();
+  private leaseCounter = 0;
+  private expiredLeases = 0;
+  private lastClaimLatencyMs = 0;
+
+  enqueue(options: EnqueueJobOptions<TPayload>, now = Date.now()): DistributedJob<TPayload> {
+    if (this.jobs.has(options.id)) {
+      throw new Error(`job ${options.id} already exists`);
+    }
+
+    const job: DistributedJob<TPayload> = {
+      id: options.id,
+      queue: options.queue ?? DEFAULT_QUEUE,
+      payload: options.payload,
+      runAt: options.runAt ?? now,
+      priority: options.priority ?? 0,
+      attempts: 0,
+      maxAttempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      status: "queued",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.jobs.set(job.id, job);
+    return cloneJob(job);
+  }
+
+  claim(options: ClaimOptions): JobLease<TPayload>[] {
+    const startedAt = performance.now();
+    const now = options.now ?? Date.now();
+    const queue = options.queue ?? DEFAULT_QUEUE;
+    const maxJobs = options.maxJobs ?? 1;
+
+    const candidates = [...this.jobs.values()]
+      .filter((job) => isClaimable(job, queue, now))
+      .sort((a, b) => b.priority - a.priority || a.runAt - b.runAt || a.createdAt - b.createdAt)
+      .slice(0, maxJobs);
+
+    const leases = candidates.map((job) => {
+      if (job.status === "leased") this.expiredLeases += 1;
+      job.status = "leased";
+      job.leaseOwner = options.workerId;
+      job.leaseExpiresAt = now + options.leaseMs;
+      job.attempts += 1;
+      job.updatedAt = now;
+      const token = `${options.workerId}:${++this.leaseCounter}`;
+      this.leaseTokens.set(token, job.id);
+      return { token, workerId: options.workerId, expiresAt: job.leaseExpiresAt, job: cloneJob(job) };
+    });
+
+    this.lastClaimLatencyMs = performance.now() - startedAt;
+    return leases;
+  }
+
+  renew(token: string, workerId: string, leaseMs: number, now = Date.now()): JobLease<TPayload> {
+    const job = this.requireOwnedJob(token, workerId, now);
+    job.leaseExpiresAt = now + leaseMs;
+    job.updatedAt = now;
+    return { token, workerId, expiresAt: job.leaseExpiresAt, job: cloneJob(job) };
+  }
+
+  complete(options: CompleteOptions): DistributedJob<TPayload> {
+    const now = options.now ?? Date.now();
+    const job = this.requireOwnedJob(options.token, options.workerId, now);
+    job.status = "completed";
+    job.leaseOwner = null;
+    job.leaseExpiresAt = null;
+    job.updatedAt = now;
+    return cloneJob(job);
+  }
+
+  fail(options: FailOptions): DistributedJob<TPayload> {
+    const now = options.now ?? Date.now();
+    const job = this.requireOwnedJob(options.token, options.workerId, now);
+    job.lastError = options.error;
+    job.leaseOwner = null;
+    job.leaseExpiresAt = null;
+    job.updatedAt = now;
+
+    if (job.attempts >= job.maxAttempts) {
+      job.status = "failed";
+    } else {
+      job.status = "queued";
+      job.runAt = now + (options.retryDelayMs ?? 0);
+    }
+    return cloneJob(job);
+  }
+
+  metrics(): SchedulerMetrics {
+    const totals = [...this.jobs.values()].reduce(
+      (acc, job) => ({ ...acc, [job.status]: acc[job.status] + 1 }),
+      { queued: 0, leased: 0, completed: 0, failed: 0 } as Record<DistributedJobStatus, number>
+    );
+    return { ...totals, expiredLeases: this.expiredLeases, claimLatencyMs: this.lastClaimLatencyMs };
+  }
+
+  snapshot(): DistributedJob<TPayload>[] {
+    return [...this.jobs.values()].map(cloneJob);
+  }
+
+  private requireOwnedJob(token: string, workerId: string, now: number): DistributedJob<TPayload> {
+    const jobId = this.leaseTokens.get(token);
+    const job = jobId ? this.jobs.get(jobId) : undefined;
+    if (!job || job.leaseOwner !== workerId || job.leaseExpiresAt === null || job.leaseExpiresAt <= now) {
+      throw new LeaseConflictError();
+    }
+    return job;
+  }
+}

--- a/tests/unit/distributedJobScheduler.test.ts
+++ b/tests/unit/distributedJobScheduler.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryDistributedJobScheduler, LeaseConflictError } from "@/services/distributedJobScheduler";
+
+describe("InMemoryDistributedJobScheduler", () => {
+  it("claims due jobs once with a lease", () => {
+    const scheduler = new InMemoryDistributedJobScheduler();
+    scheduler.enqueue({ id: "job-a", payload: { meter: "m1" } }, 1_000);
+
+    const first = scheduler.claim({ workerId: "worker-a", leaseMs: 500, now: 1_000 });
+    const second = scheduler.claim({ workerId: "worker-b", leaseMs: 500, now: 1_001 });
+
+    expect(first).toHaveLength(1);
+    expect(first[0].job.leaseOwner).toBe("worker-a");
+    expect(second).toHaveLength(0);
+  });
+
+  it("allows another worker to reclaim an expired lease", () => {
+    const scheduler = new InMemoryDistributedJobScheduler();
+    scheduler.enqueue({ id: "job-a", payload: null }, 1_000);
+    scheduler.claim({ workerId: "worker-a", leaseMs: 100, now: 1_000 });
+
+    const reclaimed = scheduler.claim({ workerId: "worker-b", leaseMs: 100, now: 1_101 });
+
+    expect(reclaimed).toHaveLength(1);
+    expect(reclaimed[0].job.leaseOwner).toBe("worker-b");
+    expect(scheduler.metrics().expiredLeases).toBe(1);
+  });
+
+  it("rejects stale completion after lease expiry", () => {
+    const scheduler = new InMemoryDistributedJobScheduler();
+    scheduler.enqueue({ id: "job-a", payload: null }, 1_000);
+    const [lease] = scheduler.claim({ workerId: "worker-a", leaseMs: 100, now: 1_000 });
+
+    expect(() => scheduler.complete({ token: lease.token, workerId: "worker-a", now: 1_101 })).toThrow(LeaseConflictError);
+  });
+
+  it("orders claims by priority then run time", () => {
+    const scheduler = new InMemoryDistributedJobScheduler();
+    scheduler.enqueue({ id: "low", payload: null, priority: 1, runAt: 900 }, 100);
+    scheduler.enqueue({ id: "high", payload: null, priority: 10, runAt: 950 }, 100);
+
+    const [lease] = scheduler.claim({ workerId: "worker-a", leaseMs: 100, maxJobs: 1, now: 1_000 });
+
+    expect(lease.job.id).toBe("high");
+  });
+
+  it("retries failed jobs until max attempts", () => {
+    const scheduler = new InMemoryDistributedJobScheduler();
+    scheduler.enqueue({ id: "job-a", payload: null, maxAttempts: 2 }, 1_000);
+    const [first] = scheduler.claim({ workerId: "worker-a", leaseMs: 100, now: 1_000 });
+    scheduler.fail({ token: first.token, workerId: "worker-a", error: "timeout", retryDelayMs: 50, now: 1_010 });
+
+    const [second] = scheduler.claim({ workerId: "worker-b", leaseMs: 100, now: 1_060 });
+    const failed = scheduler.fail({ token: second.token, workerId: "worker-b", error: "timeout", now: 1_070 });
+
+    expect(failed.status).toBe("failed");
+    expect(scheduler.metrics().failed).toBe(1);
+  });
+});


### PR DESCRIPTION
Motivation
Provide a lease-based distributed job scheduler to ensure exactly-one execution semantics and safe recovery when workers crash.
Ship a testable in-memory core that defines the storage/transaction contract and can be backed by a production datastore with conditional writes for sub-100ms claim paths.
Include operational guidance and runbooks so monitoring, alerts, and blue/green canary deployments are specified alongside the implementation.
Description
Add src/services/distributedJobScheduler.ts implementing job types and InMemoryDistributedJobScheduler with claim, renew, complete, fail, metrics, and snapshot APIs plus lease-token tracking and lease-conflict protection.
Add tests/unit/distributedJobScheduler.test.ts with Vitest cases that exercise exclusive claiming, expired-lease reclaiming, stale completion rejection, priority ordering, and retry exhaustion.
Add architecture documentation docs/distributed-job-scheduler.md describing the critical path, datastore contract, monitoring signals, and deployment guidance.
Add an operational runbook docs/runbooks/distributed-job-scheduler.md covering triage and recovery steps for queue pressure, claim latency, expired leases, and canary problems.
Testing
Ran the unit tests with vitest for the new scheduler tests and all tests in tests/unit/distributedJobScheduler.test.ts passed (5 tests).
Verified TypeScript with npx tsc --noEmit, which succeeded.
Ran npx eslint on the added files which reported no issues for the new code.
A full npm run lint run fails due to pre-existing unused-variable errors in src/components/map/AssetHeatmapLayer.tsx, which are unrelated to this change.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/120