### PR TITLE
Api rate limiting with per tenant

### DIFF
--- a/docs/architecture/rate-limiting.md
+++ b/docs/architecture/rate-limiting.md
@@ -1,0 +1,39 @@
+# API Rate Limiting with Per-Tenant Token Buckets
+
+## Goals
+
+- Enforce tenant-scoped quotas before expensive request handling begins.
+- Keep the critical path below 100ms P99 by using O(1) in-memory bucket updates.
+- Preserve availability by failing closed only for malformed policies and returning deterministic `429` responses for exhausted tenants.
+
+## Architecture
+
+Requests are mapped to a tenant by `x-tenant-id`, then `x-api-key-tenant`, then the `anonymous` fallback. Each tenant owns an independent token bucket with:
+
+- `capacity`: maximum burst size.
+- `refillRatePerSecond`: sustained request rate.
+- `ttlMs`: idle bucket retention window.
+
+The shared route helper consumes tokens and emits standard `RateLimit-*` and `Retry-After` headers. Services should invoke `checkTenantRateLimit()` at the top of every App Router route handler, then return `rateLimitResponse()` when present.
+
+## Monitoring and alerts
+
+Track these metrics per tenant and route:
+
+- `rate_limit_allowed_total`
+- `rate_limit_blocked_total`
+- `rate_limit_remaining_tokens`
+- `rate_limit_decision_latency_ms`
+
+Alert when blocked traffic exceeds 5% for a tenant for 5 minutes, decision latency exceeds 25ms P99, or anonymous traffic exceeds expected baselines.
+
+## Deployment
+
+1. Ship the helper dark-launched with headers only.
+2. Enable enforcement for internal tenants during a blue-green deployment.
+3. Canary 5%, 25%, 50%, then 100% of external traffic while comparing `429` rates and route latency.
+4. Roll back by disabling enforcement or restoring the previous green environment.
+
+## Security notes
+
+Tenant identity must come from trusted authentication middleware in production. Direct `x-tenant-id` use is acceptable only behind an API gateway that strips untrusted inbound tenant headers and injects verified values.

--- a/docs/runbooks/rate-limiting.md
+++ b/docs/runbooks/rate-limiting.md
@@ -1,0 +1,25 @@
+# Rate Limiting Runbook
+
+## Symptoms
+
+- Tenants receive HTTP `429` responses.
+- `rate_limit_blocked_total` increases for one or more routes.
+- Support reports missing or low `RateLimit-Remaining` headers.
+
+## Triage
+
+1. Confirm the tenant ID and route from logs or response headers.
+2. Check `rate_limit_blocked_total` and `rate_limit_decision_latency_ms` dashboards.
+3. Compare current request rate with the configured tenant policy.
+4. Verify the gateway is injecting a trusted tenant identity.
+
+## Mitigation
+
+- For legitimate bursts, temporarily raise `capacity` for the impacted tenant.
+- For sustained growth, raise `refillRatePerSecond` after capacity planning.
+- For abusive traffic, keep enforcement enabled and notify security.
+- If enforcement causes broad false positives, roll back to the previous blue-green environment.
+
+## Post-incident
+
+Document the tenant, policy, blocked duration, customer impact, and whether dashboard or alert thresholds need adjustment.

--- a/src/app/api/rate-limit/route.ts
+++ b/src/app/api/rate-limit/route.ts
@@ -1,0 +1,19 @@
+import { checkTenantRateLimit, rateLimitHeaders, rateLimitResponse } from "@/utils/rateLimit/http";
+
+export async function GET(request: Request) {
+  const decision = checkTenantRateLimit(request);
+  const blocked = rateLimitResponse(decision);
+
+  if (blocked) return blocked;
+
+  return Response.json(
+    {
+      ok: true,
+      tenantId: decision.tenantId,
+      remaining: decision.remaining,
+    },
+    {
+      headers: rateLimitHeaders(decision),
+    }
+  );
+}

--- a/src/utils/rateLimit/http.ts
+++ b/src/utils/rateLimit/http.ts
@@ -1,0 +1,66 @@
+import { TokenBucketRateLimiter, type RateLimitDecision, type TenantRateLimitPolicy } from "./tokenBucket";
+
+export const DEFAULT_TENANT_RATE_LIMIT_POLICY: TenantRateLimitPolicy = {
+  capacity: 120,
+  refillRatePerSecond: 20,
+  ttlMs: 10 * 60 * 1000,
+};
+
+export const tenantRateLimiter = new TokenBucketRateLimiter();
+
+export function resolveTenantId(request: Request): string {
+  const tenantId = request.headers.get("x-tenant-id")?.trim();
+  const apiKeyTenant = request.headers.get("x-api-key-tenant")?.trim();
+
+  if (tenantId) return tenantId;
+  if (apiKeyTenant) return apiKeyTenant;
+
+  return "anonymous";
+}
+
+export function rateLimitHeaders(decision: RateLimitDecision): HeadersInit {
+  const headers: Record<string, string> = {
+    "RateLimit-Limit": String(decision.limit),
+    "RateLimit-Remaining": String(decision.remaining),
+    "RateLimit-Reset": String(Math.ceil(decision.resetAt / 1000)),
+    "X-RateLimit-Tenant": decision.tenantId,
+  };
+
+  if (!decision.allowed) {
+    headers["Retry-After"] = String(Math.ceil(decision.retryAfterMs / 1000));
+  }
+
+  return headers;
+}
+
+export function checkTenantRateLimit(
+  request: Request,
+  policy: TenantRateLimitPolicy = DEFAULT_TENANT_RATE_LIMIT_POLICY,
+  cost = 1
+): RateLimitDecision {
+  const tenantId = resolveTenantId(request);
+  const decision = tenantRateLimiter.consume(tenantId, policy, cost);
+
+  if (policy.ttlMs) {
+    tenantRateLimiter.pruneExpired(policy.ttlMs);
+  }
+
+  return decision;
+}
+
+export function rateLimitResponse(decision: RateLimitDecision): Response | null {
+  if (decision.allowed) return null;
+
+  return Response.json(
+    {
+      error: "rate_limited",
+      message: "Tenant request quota exceeded. Retry after the advertised delay.",
+      tenantId: decision.tenantId,
+      retryAfterMs: decision.retryAfterMs,
+    },
+    {
+      status: 429,
+      headers: rateLimitHeaders(decision),
+    }
+  );
+}

--- a/src/utils/rateLimit/tokenBucket.ts
+++ b/src/utils/rateLimit/tokenBucket.ts
@@ -1,0 +1,142 @@
+export type TenantId = string;
+
+export interface TenantRateLimitPolicy {
+  capacity: number;
+  refillRatePerSecond: number;
+  ttlMs?: number;
+}
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  tenantId: TenantId;
+  limit: number;
+  remaining: number;
+  retryAfterMs: number;
+  resetAt: number;
+}
+
+interface BucketState {
+  tokens: number;
+  updatedAt: number;
+  lastSeenAt: number;
+}
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+function validatePolicy(policy: TenantRateLimitPolicy): void {
+  if (!Number.isFinite(policy.capacity) || policy.capacity <= 0) {
+    throw new Error("Rate limit capacity must be a positive finite number.");
+  }
+
+  if (!Number.isFinite(policy.refillRatePerSecond) || policy.refillRatePerSecond <= 0) {
+    throw new Error("Rate limit refillRatePerSecond must be a positive finite number.");
+  }
+}
+
+export class TokenBucketRateLimiter {
+  private readonly buckets = new Map<TenantId, BucketState>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  consume(
+    tenantId: TenantId,
+    policy: TenantRateLimitPolicy,
+    cost = 1
+  ): RateLimitDecision {
+    validatePolicy(policy);
+
+    if (!tenantId.trim()) {
+      throw new Error("tenantId is required for rate limiting.");
+    }
+
+    if (!Number.isFinite(cost) || cost <= 0) {
+      throw new Error("Rate limit cost must be a positive finite number.");
+    }
+
+    const now = this.now();
+    const bucket = this.refill(tenantId, policy, now);
+    const allowed = bucket.tokens >= cost;
+
+    if (allowed) {
+      bucket.tokens -= cost;
+    }
+
+    bucket.lastSeenAt = now;
+    this.buckets.set(tenantId, bucket);
+
+    const missingTokens = allowed ? 0 : cost - bucket.tokens;
+    const retryAfterMs = Math.ceil((missingTokens / policy.refillRatePerSecond) * 1000);
+    const resetAt = Math.ceil(
+      now + ((policy.capacity - bucket.tokens) / policy.refillRatePerSecond) * 1000
+    );
+
+    return {
+      allowed,
+      tenantId,
+      limit: policy.capacity,
+      remaining: Math.max(0, Math.floor(bucket.tokens)),
+      retryAfterMs,
+      resetAt,
+    };
+  }
+
+  snapshot(tenantId: TenantId, policy: TenantRateLimitPolicy): RateLimitDecision {
+    validatePolicy(policy);
+
+    const now = this.now();
+    const bucket = this.refill(tenantId, policy, now);
+
+    return {
+      allowed: bucket.tokens >= 1,
+      tenantId,
+      limit: policy.capacity,
+      remaining: Math.max(0, Math.floor(bucket.tokens)),
+      retryAfterMs:
+        bucket.tokens >= 1
+          ? 0
+          : Math.ceil(((1 - bucket.tokens) / policy.refillRatePerSecond) * 1000),
+      resetAt: Math.ceil(
+        now + ((policy.capacity - bucket.tokens) / policy.refillRatePerSecond) * 1000
+      ),
+    };
+  }
+
+  pruneExpired(ttlMs = DEFAULT_TTL_MS): number {
+    const cutoff = this.now() - ttlMs;
+    let pruned = 0;
+
+    for (const [tenantId, bucket] of this.buckets) {
+      if (bucket.lastSeenAt < cutoff) {
+        this.buckets.delete(tenantId);
+        pruned += 1;
+      }
+    }
+
+    return pruned;
+  }
+
+  size(): number {
+    return this.buckets.size;
+  }
+
+  private refill(
+    tenantId: TenantId,
+    policy: TenantRateLimitPolicy,
+    now: number
+  ): BucketState {
+    const existing = this.buckets.get(tenantId) ?? {
+      tokens: policy.capacity,
+      updatedAt: now,
+      lastSeenAt: now,
+    };
+
+    const elapsedMs = Math.max(0, now - existing.updatedAt);
+    const refilledTokens = (elapsedMs / 1000) * policy.refillRatePerSecond;
+
+    return {
+      tokens: Math.min(policy.capacity, existing.tokens + refilledTokens),
+      updatedAt: now,
+      lastSeenAt: existing.lastSeenAt,
+    };
+  }
+}

--- a/tests/unit/tokenBucketRateLimiter.test.ts
+++ b/tests/unit/tokenBucketRateLimiter.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { TokenBucketRateLimiter } from "@/utils/rateLimit/tokenBucket";
+
+const policy = {
+  capacity: 3,
+  refillRatePerSecond: 1,
+};
+
+describe("TokenBucketRateLimiter", () => {
+  it("isolates token buckets per tenant", () => {
+    const now = 0;
+    const limiter = new TokenBucketRateLimiter(() => now);
+
+    expect(limiter.consume("tenant-a", policy).allowed).toBe(true);
+    expect(limiter.consume("tenant-a", policy).remaining).toBe(1);
+    expect(limiter.consume("tenant-b", policy).remaining).toBe(2);
+  });
+
+  it("blocks when the bucket is empty and reports retry metadata", () => {
+    const now = 0;
+    const limiter = new TokenBucketRateLimiter(() => now);
+
+    limiter.consume("tenant-a", policy);
+    limiter.consume("tenant-a", policy);
+    limiter.consume("tenant-a", policy);
+
+    const decision = limiter.consume("tenant-a", policy);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.remaining).toBe(0);
+    expect(decision.retryAfterMs).toBe(1000);
+    expect(decision.resetAt).toBe(3000);
+  });
+
+  it("refills tokens over time without exceeding capacity", () => {
+    let now = 0;
+    const limiter = new TokenBucketRateLimiter(() => now);
+
+    limiter.consume("tenant-a", policy, 3);
+    now = 1500;
+
+    const decision = limiter.consume("tenant-a", policy);
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.remaining).toBe(0);
+
+    now = 10_000;
+    expect(limiter.snapshot("tenant-a", policy).remaining).toBe(3);
+  });
+
+  it("prunes idle tenant buckets", () => {
+    let now = 0;
+    const limiter = new TokenBucketRateLimiter(() => now);
+
+    limiter.consume("tenant-a", policy);
+    limiter.consume("tenant-b", policy);
+    now = 10_001;
+
+    expect(limiter.pruneExpired(10_000)).toBe(2);
+    expect(limiter.size()).toBe(0);
+  });
+
+  it("rejects missing tenants and invalid policies", () => {
+    const limiter = new TokenBucketRateLimiter(() => 0);
+
+    expect(() => limiter.consume(" ", policy)).toThrow("tenantId is required");
+    expect(() => limiter.consume("tenant-a", { capacity: 0, refillRatePerSecond: 1 })).toThrow(
+      "capacity"
+    );
+    expect(() => limiter.consume("tenant-a", { capacity: 1, refillRatePerSecond: 0 })).toThrow(
+      "refillRatePerSecond"
+    );
+  });
+});


### PR DESCRIPTION
Motivation
Enforce tenant-scoped API quotas early in the request lifecycle using an efficient in-memory token-bucket to meet the <100ms P99 and 99.99% availability targets.
Provide a reusable helper and a clear enforcement pattern for App Router route handlers that services can adopt system-wide.
Description
Add a TokenBucketRateLimiter implementation with consume, snapshot, pruneExpired, and size operations and defensive policy validation in src/utils/rateLimit/tokenBucket.ts.
Add HTTP helpers and defaults in src/utils/rateLimit/http.ts including resolveTenantId, checkTenantRateLimit, rateLimitHeaders, and rateLimitResponse which emit RateLimit-* and Retry-After headers.
Add a demo App Router route GET /api/rate-limit at src/app/api/rate-limit/route.ts to show top-of-handler enforcement.
Add documentation and operational runbook at docs/architecture/rate-limiting.md and docs/runbooks/rate-limiting.md, and add unit tests in tests/unit/tokenBucketRateLimiter.test.ts covering tenant isolation, exhaustion, refill, pruning, and validation errors.
Testing
Ran npm test -- tests/unit/tokenBucketRateLimiter.test.ts and all tests in that file passed (5 passed).
Ran targeted linting npx eslint on the new files and npx tsc --noEmit and both succeeded for the changed files.
Full-repo npm run lint currently reports pre-existing unused-variable errors in src/components/map/AssetHeatmapLayer.tsx which are unrelated to this change.
npm run build failed in the environment due to external Google Fonts fetch errors for Geist/Geist Mono during the Turbopack build, not due to the rate-limiting changes.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/117