### PR TITLE
Service mesh integration

### DIFF
--- a/deploy/istio/utility-frontend-mtls.yaml
+++ b/deploy/istio/utility-frontend-mtls.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: utility-frontend
+  labels:
+    istio-injection: enabled
+---
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: default-strict-mtls
+  namespace: utility-frontend
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-ingress-gateway-to-frontend
+  namespace: utility-frontend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: utility-frontend
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
+      to:
+        - operation:
+            methods: ["GET", "POST", "HEAD"]
+            ports: ["3000"]
+---
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: frontend-request-security-telemetry
+  namespace: utility-frontend
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: utility-frontend
+  metrics:
+    - providers:
+        - name: prometheus
+      overrides:
+        - match:
+            metric: REQUEST_DURATION
+          tagOverrides:
+            security_policy:
+              value: '"strict-mtls"'
+            workload:
+              value: '"utility-frontend"'
+  accessLogging:
+    - providers:
+        - name: envoy
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: utility-frontend-mtls
+  namespace: utility-frontend
+spec:
+  host: utility-frontend.utility-frontend.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    connectionPool:
+      tcp:
+        maxConnections: 1024
+      http:
+        http2MaxRequests: 4096
+        maxRequestsPerConnection: 256
+    outlierDetection:
+      consecutive5xxErrors: 3
+      interval: 10s
+      baseEjectionTime: 30s
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: utility-frontend-blue-green-canary
+  namespace: utility-frontend
+spec:
+  hosts:
+    - utility.example.com
+  gateways:
+    - istio-system/public-gateway
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: utility-frontend.utility-frontend.svc.cluster.local
+            subset: blue
+          weight: 95
+        - destination:
+            host: utility-frontend.utility-frontend.svc.cluster.local
+            subset: green
+          weight: 5

--- a/docs/service-mesh-mtls.md
+++ b/docs/service-mesh-mtls.md
@@ -1,0 +1,40 @@
+# Service Mesh Integration with Mutual TLS
+
+## Architecture
+
+The frontend runs in the `utility-frontend` namespace with automatic sidecar injection. Istio enforces namespace-wide `STRICT` mutual TLS through `PeerAuthentication`; clients must use mesh-issued workload identities and `ISTIO_MUTUAL` transport defined by the destination rule.
+
+Traffic enters through the public Istio gateway, then routes to blue and green subsets for canary analysis. Authorization is default-deny except for the ingress gateway service account, which may call the frontend on port `3000` with `GET`, `POST`, and `HEAD`.
+
+## SLOs and rollout gates
+
+- Critical path latency: P99 must remain below `100ms`; telemetry ingest is budgeted at `75ms`.
+- Availability: `99.99%` monthly uptime target.
+- Canary stages: 5% for 15 minutes, 25% for 30 minutes, 50% for 30 minutes, then 100% for 30 minutes.
+- Roll back immediately if P99 exceeds budget for two consecutive five-minute windows, 5xx rate exceeds 1%, or mTLS authorization failures increase above baseline.
+
+## Monitoring and alerting
+
+Use Prometheus metrics emitted by Istio telemetry:
+
+- `istio_request_duration_milliseconds_bucket` filtered by `destination_workload="utility-frontend"` for P99 latency.
+- `istio_requests_total` with response-code labels for availability and 5xx burn-rate alerts.
+- Envoy access logs tagged with `security_policy="strict-mtls"` for security review evidence.
+
+Dashboards should include request rate, P50/P95/P99 latency, 4xx/5xx error rates, active canary weights, mTLS mode, and authorization-denied counts.
+
+## Deployment runbook
+
+1. Apply the mesh manifest: `kubectl apply -f deploy/istio/utility-frontend-mtls.yaml`.
+2. Confirm sidecar injection on new pods: `kubectl -n utility-frontend get pods -o jsonpath='{.items[*].spec.containers[*].name}'`.
+3. Confirm strict mTLS: `istioctl authn tls-check deploy/utility-frontend -n utility-frontend`.
+4. Start at the 5% green route and watch the dashboard for at least 15 minutes.
+5. Advance canary weights only when latency, error-rate, and authorization-denied alerts stay green.
+6. Promote green to 100% or restore blue to 100% if a rollback gate triggers.
+
+## Security review checklist
+
+- `PeerAuthentication` remains `STRICT` for the namespace.
+- `AuthorizationPolicy` contains only required principals, methods, and ports.
+- Dashboard evidence covers latency, availability, and mTLS authorization outcomes.
+- Runbook records the exact manifest version, rollout timestamps, and rollback decision points.

--- a/src/config/serviceMesh.ts
+++ b/src/config/serviceMesh.ts
@@ -1,0 +1,64 @@
+export type MeshMode = "STRICT" | "PERMISSIVE" | "DISABLE";
+export type TelemetryLevel = "request" | "workload" | "security";
+
+export interface CriticalPathBudget {
+  readonly route: string;
+  readonly p99BudgetMs: number;
+}
+
+export interface MeshCanaryStep {
+  readonly weightPercent: number;
+  readonly durationMinutes: number;
+}
+
+export interface ServiceMeshPolicy {
+  readonly namespace: string;
+  readonly mtlsMode: MeshMode;
+  readonly availabilityTarget: number;
+  readonly criticalPathP99Ms: number;
+  readonly telemetryLevels: readonly TelemetryLevel[];
+  readonly criticalPaths: readonly CriticalPathBudget[];
+  readonly canary: readonly MeshCanaryStep[];
+}
+
+export const serviceMeshPolicy: ServiceMeshPolicy = {
+  namespace: "utility-frontend",
+  mtlsMode: "STRICT",
+  availabilityTarget: 0.9999,
+  criticalPathP99Ms: 100,
+  telemetryLevels: ["request", "workload", "security"],
+  criticalPaths: [
+    { route: "/", p99BudgetMs: 100 },
+    { route: "/export", p99BudgetMs: 100 },
+    { route: "/api/telemetry/ingest", p99BudgetMs: 75 },
+  ],
+  canary: [
+    { weightPercent: 5, durationMinutes: 15 },
+    { weightPercent: 25, durationMinutes: 30 },
+    { weightPercent: 50, durationMinutes: 30 },
+    { weightPercent: 100, durationMinutes: 30 },
+  ],
+};
+
+export function validateServiceMeshPolicy(policy: ServiceMeshPolicy): string[] {
+  const errors: string[] = [];
+
+  if (policy.mtlsMode !== "STRICT") errors.push("mTLS mode must be STRICT");
+  if (policy.availabilityTarget < 0.9999) {
+    errors.push("availability target must be at least 99.99%");
+  }
+  if (policy.criticalPathP99Ms > 100) {
+    errors.push("critical path P99 budget must be <= 100ms");
+  }
+  if (!policy.telemetryLevels.includes("security")) {
+    errors.push("security telemetry must be enabled");
+  }
+  if (policy.criticalPaths.some((path) => path.p99BudgetMs > policy.criticalPathP99Ms)) {
+    errors.push("all critical paths must fit within the global P99 budget");
+  }
+  if (policy.canary.length === 0 || policy.canary.at(-1)?.weightPercent !== 100) {
+    errors.push("canary rollout must end at 100% traffic");
+  }
+
+  return errors;
+}

--- a/tests/unit/serviceMesh.test.ts
+++ b/tests/unit/serviceMesh.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { serviceMeshPolicy, validateServiceMeshPolicy } from "@/config/serviceMesh";
+
+describe("service mesh policy", () => {
+  it("keeps the baseline policy inside the issue bounds", () => {
+    expect(validateServiceMeshPolicy(serviceMeshPolicy)).toEqual([]);
+  });
+
+  it("rejects permissive mTLS, weak availability, missing security telemetry, and slow paths", () => {
+    expect(
+      validateServiceMeshPolicy({
+        ...serviceMeshPolicy,
+        mtlsMode: "PERMISSIVE",
+        availabilityTarget: 0.999,
+        criticalPathP99Ms: 150,
+        telemetryLevels: ["request"],
+        criticalPaths: [{ route: "/", p99BudgetMs: 200 }],
+        canary: [{ weightPercent: 50, durationMinutes: 10 }],
+      }),
+    ).toEqual([
+      "mTLS mode must be STRICT",
+      "availability target must be at least 99.99%",
+      "critical path P99 budget must be <= 100ms",
+      "security telemetry must be enabled",
+      "all critical paths must fit within the global P99 budget",
+      "canary rollout must end at 100% traffic",
+    ]);
+  });
+});


### PR DESCRIPTION
Motivation
Provide a system-wide plan and artifacts to integrate the frontend into a service mesh with strict mutual TLS and safe canary rollout behavior.
Define operational guardrails (SLOs, telemetry, rollout gates) so deployments meet the <100ms P99 and 99.99% availability targets.
Give operators a repeatable runbook, Prometheus/Envoy telemetry guidance, and configuration suitable for security review.
Description
Add Istio manifests in deploy/istio/utility-frontend-mtls.yaml including Namespace with sidecar injection, PeerAuthentication (STRICT mTLS), AuthorizationPolicy, Telemetry, DestinationRule (ISTIO_MUTUAL), and a VirtualService wired for blue/green canary routing.
Add documentation docs/service-mesh-mtls.md describing the architecture, SLOs, monitoring/alerting, deployment runbook, and security-review checklist.
Add a typed guardrail module src/config/serviceMesh.ts exposing serviceMeshPolicy and a validator function validateServiceMeshPolicy that enforces STRICT mTLS, availability >= 0.9999, global P99 budget <= 100ms, presence of security telemetry, and that the canary ends at 100% traffic.
Add unit tests tests/unit/serviceMesh.test.ts that assert the baseline policy is valid and that unsafe/relaxed policies are rejected with the expected validation errors.
Testing
Ran npm test -- tests/unit/serviceMesh.test.ts and the unit file executed successfully with the two tests passing.
Ran npm run lint which reported pre-existing ESLint errors in src/components/map/AssetHeatmapLayer.tsx unrelated to this change and therefore the lint step failed.
No other automated tests were changed; the added unit tests passed in the CI-local run described above.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/116