### PR TITLE
In memory cache layer

### DIFF
--- a/docs/redis-cache.md
+++ b/docs/redis-cache.md
@@ -1,0 +1,43 @@
+# Redis-backed in-memory cache
+
+## Architecture
+
+The cache layer is a two-tier service:
+
+1. An in-process LRU memory cache for sub-millisecond repeat reads on hot critical paths.
+2. An optional Redis adapter for shared, cross-instance durability. Redis failures are treated as best-effort and fall back to the local in-memory tier so request handling remains available.
+
+`RedisBackedCache` stores JSON-serialized values under namespaced keys and applies a configurable TTL to every write. Services should wrap expensive calls with `systemCache.remember(key, factory, ttlMs)` so a miss computes and stores the value once while subsequent reads are served from cache.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `CACHE_NAMESPACE` | `utility` | Prefix isolating cache keys per environment. |
+| `CACHE_DEFAULT_TTL_MS` | `60000` | Default TTL for entries that do not provide one. |
+| `CACHE_MAX_MEMORY_ENTRIES` | `1000` | Maximum hot entries retained by the in-process tier. |
+| `UPSTASH_REDIS_REST_URL` | unset | Enables the shared Redis tier through the Upstash Redis REST API. |
+| `UPSTASH_REDIS_REST_TOKEN` | unset | Bearer token for the shared Redis tier. |
+
+Choose TTLs per data domain. Critical paths should use the shortest TTL that still keeps P99 latency under 100ms without serving unsafe stale data.
+
+## Monitoring and alerts
+
+Expose `snapshotMetrics()` to telemetry and alert on:
+
+- sustained `misses / (hits + misses) > 0.25` for critical paths;
+- any `redisFallbacks` burst lasting longer than five minutes;
+- rising `errors` or `evictions` after a deployment.
+
+Dashboards should chart hit rate, miss rate, Redis fallback count, write/delete volume, and memory evictions by service and cache namespace.
+
+## Deployment and operations
+
+Deploy with blue-green infrastructure. During canary analysis, compare hit rate, Redis fallbacks, P99 latency, and error rate between the old and new pools before shifting all traffic.
+
+Runbook:
+
+1. If Redis is degraded, keep traffic on the active pool; the cache continues from memory but hit rate may drop after restarts.
+2. Lower `CACHE_DEFAULT_TTL_MS` for data correctness incidents, then invalidate affected key namespaces.
+3. Raise `CACHE_MAX_MEMORY_ENTRIES` only after checking process memory headroom.
+4. Roll back if P99 latency exceeds 100ms or Redis fallback alerts remain active after remediation.

--- a/src/services/redisCache.ts
+++ b/src/services/redisCache.ts
@@ -1,0 +1,252 @@
+export interface CacheMetrics {
+  hits: number;
+  misses: number;
+  writes: number;
+  deletes: number;
+  errors: number;
+  evictions: number;
+  redisFallbacks: number;
+}
+
+export interface CacheOptions {
+  namespace?: string;
+  defaultTtlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+  redis?: RedisCacheAdapter;
+  onMetric?: (metric: keyof CacheMetrics, value: number) => void;
+}
+
+export interface RedisCacheAdapter {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttlMs: number): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+interface MemoryEntry {
+  value: string;
+  expiresAt: number;
+  lastAccessedAt: number;
+}
+
+export const DEFAULT_CACHE_TTL_MS = 60_000;
+export const DEFAULT_MAX_CACHE_ENTRIES = 1_000;
+
+export class RedisBackedCache {
+  private readonly namespace: string;
+  private readonly defaultTtlMs: number;
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+  private readonly redis?: RedisCacheAdapter;
+  private readonly onMetric?: (metric: keyof CacheMetrics, value: number) => void;
+  private readonly memory = new Map<string, MemoryEntry>();
+  private readonly metrics: CacheMetrics = {
+    hits: 0,
+    misses: 0,
+    writes: 0,
+    deletes: 0,
+    errors: 0,
+    evictions: 0,
+    redisFallbacks: 0,
+  };
+
+  constructor(options: CacheOptions = {}) {
+    this.namespace = options.namespace ?? "utility";
+    this.defaultTtlMs = options.defaultTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_CACHE_ENTRIES;
+    this.now = options.now ?? Date.now;
+    this.redis = options.redis;
+    this.onMetric = options.onMetric;
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    const namespacedKey = this.key(key);
+    const memoryValue = this.getFromMemory(namespacedKey);
+    if (memoryValue !== null) {
+      this.record("hits");
+      return this.parse<T>(memoryValue);
+    }
+
+    if (this.redis) {
+      try {
+        const redisValue = await this.redis.get(namespacedKey);
+        if (redisValue !== null) {
+          this.memory.set(namespacedKey, {
+            value: redisValue,
+            expiresAt: this.now() + this.defaultTtlMs,
+            lastAccessedAt: this.now(),
+          });
+          this.evictIfNeeded();
+          this.record("hits");
+          return this.parse<T>(redisValue);
+        }
+      } catch {
+        this.record("errors");
+        this.record("redisFallbacks");
+      }
+    }
+
+    this.record("misses");
+    return null;
+  }
+
+  async set<T>(key: string, value: T, ttlMs = this.defaultTtlMs): Promise<void> {
+    const namespacedKey = this.key(key);
+    const serialized = JSON.stringify(value);
+    this.memory.set(namespacedKey, {
+      value: serialized,
+      expiresAt: this.now() + ttlMs,
+      lastAccessedAt: this.now(),
+    });
+    this.evictIfNeeded();
+
+    if (this.redis) {
+      try {
+        await this.redis.set(namespacedKey, serialized, ttlMs);
+      } catch {
+        this.record("errors");
+        this.record("redisFallbacks");
+      }
+    }
+
+    this.record("writes");
+  }
+
+  async delete(key: string): Promise<void> {
+    const namespacedKey = this.key(key);
+    this.memory.delete(namespacedKey);
+    if (this.redis) {
+      try {
+        await this.redis.delete(namespacedKey);
+      } catch {
+        this.record("errors");
+        this.record("redisFallbacks");
+      }
+    }
+    this.record("deletes");
+  }
+
+  async remember<T>(key: string, factory: () => Promise<T>, ttlMs = this.defaultTtlMs): Promise<T> {
+    const cached = await this.get<T>(key);
+    if (cached !== null) return cached;
+
+    const value = await factory();
+    await this.set(key, value, ttlMs);
+    return value;
+  }
+
+  clearMemory(): void {
+    this.memory.clear();
+  }
+
+  snapshotMetrics(): CacheMetrics {
+    return { ...this.metrics };
+  }
+
+  private getFromMemory(key: string): string | null {
+    const entry = this.memory.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= this.now()) {
+      this.memory.delete(key);
+      this.record("evictions");
+      return null;
+    }
+    entry.lastAccessedAt = this.now();
+    return entry.value;
+  }
+
+  private key(key: string): string {
+    return `${this.namespace}:${key}`;
+  }
+
+  private parse<T>(value: string): T | null {
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      this.record("errors");
+      return null;
+    }
+  }
+
+  private evictIfNeeded(): void {
+    while (this.memory.size > this.maxEntries) {
+      let oldestKey: string | undefined;
+      let oldestAccess = Infinity;
+      for (const [key, entry] of this.memory) {
+        if (entry.lastAccessedAt < oldestAccess) {
+          oldestAccess = entry.lastAccessedAt;
+          oldestKey = key;
+        }
+      }
+      if (!oldestKey) return;
+      this.memory.delete(oldestKey);
+      this.record("evictions");
+    }
+  }
+
+  private record(metric: keyof CacheMetrics): void {
+    this.metrics[metric] += 1;
+    this.onMetric?.(metric, this.metrics[metric]);
+  }
+}
+
+export function createUpstashRedisAdapter(options: {
+  url: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): RedisCacheAdapter {
+  const fetcher = options.fetchImpl ?? fetch;
+  const request = async <T>(command: unknown[]): Promise<T> => {
+    const response = await fetcher(options.url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${options.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(command),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Redis request failed with ${response.status}`);
+    }
+
+    const payload = (await response.json()) as { result?: T; error?: string };
+    if (payload.error) throw new Error(payload.error);
+    return payload.result as T;
+  };
+
+  return {
+    get: (key) => request<string | null>(["GET", key]),
+    set: async (key, value, ttlMs) => {
+      await request<string>(["SET", key, value, "PX", ttlMs]);
+    },
+    delete: async (key) => {
+      await request<number>(["DEL", key]);
+    },
+  };
+}
+
+export function createCacheFromEnv(env: Record<string, string | undefined> = process.env): RedisBackedCache {
+  const redis =
+    env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN
+      ? createUpstashRedisAdapter({
+          url: env.UPSTASH_REDIS_REST_URL,
+          token: env.UPSTASH_REDIS_REST_TOKEN,
+        })
+      : undefined;
+
+  return new RedisBackedCache({
+    namespace: env.CACHE_NAMESPACE,
+    defaultTtlMs: parsePositiveInt(env.CACHE_DEFAULT_TTL_MS, DEFAULT_CACHE_TTL_MS),
+    maxEntries: parsePositiveInt(env.CACHE_MAX_MEMORY_ENTRIES, DEFAULT_MAX_CACHE_ENTRIES),
+    redis,
+  });
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export const systemCache = createCacheFromEnv();

--- a/tests/unit/redisCache.test.ts
+++ b/tests/unit/redisCache.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { RedisBackedCache, createUpstashRedisAdapter, type RedisCacheAdapter } from "@/services/redisCache";
+
+function clock(start = 1_000) {
+  let now = start;
+  return { now: () => now, tick: (ms: number) => (now += ms) };
+}
+
+describe("RedisBackedCache", () => {
+  it("serves fresh values from memory within the configured TTL", async () => {
+    const time = clock();
+    const cache = new RedisBackedCache({ now: time.now, defaultTtlMs: 500 });
+
+    await cache.set("critical-path", { ok: true });
+    time.tick(499);
+
+    expect(await cache.get("critical-path")).toEqual({ ok: true });
+    expect(cache.snapshotMetrics().hits).toBe(1);
+  });
+
+  it("expires memory entries and reports a miss after TTL", async () => {
+    const time = clock();
+    const cache = new RedisBackedCache({ now: time.now, defaultTtlMs: 100 });
+
+    await cache.set("quote", 10);
+    time.tick(101);
+
+    expect(await cache.get("quote")).toBeNull();
+    expect(cache.snapshotMetrics()).toMatchObject({ misses: 1, evictions: 1 });
+  });
+
+  it("hydrates memory from Redis and namespaces keys", async () => {
+    const adapter: RedisCacheAdapter = {
+      get: vi.fn(async () => JSON.stringify({ from: "redis" })),
+      set: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    };
+    const cache = new RedisBackedCache({ namespace: "test", redis: adapter });
+
+    expect(await cache.get("ledger:latest")).toEqual({ from: "redis" });
+    expect(adapter.get).toHaveBeenCalledWith("test:ledger:latest");
+  });
+
+  it("falls back to memory when Redis writes fail", async () => {
+    const adapter: RedisCacheAdapter = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => { throw new Error("redis down"); }),
+      delete: vi.fn(async () => undefined),
+    };
+    const cache = new RedisBackedCache({ redis: adapter });
+
+    await cache.set("asset", { id: "A" });
+
+    expect(await cache.get("asset")).toEqual({ id: "A" });
+    expect(cache.snapshotMetrics()).toMatchObject({ errors: 1, redisFallbacks: 1 });
+  });
+
+  it("creates an Upstash Redis REST adapter", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ result: "OK" }), { status: 200 })
+    );
+    const adapter = createUpstashRedisAdapter({
+      url: "https://redis.example.com",
+      token: "secret",
+      fetchImpl,
+    });
+
+    await adapter.set("utility:key", "value", 250);
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://redis.example.com", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer secret",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(["SET", "utility:key", "value", "PX", 250]),
+    });
+  });
+
+  it("coalesces cache misses with remember", async () => {
+    const cache = new RedisBackedCache();
+    const factory = vi.fn(async () => "value");
+
+    await expect(cache.remember("expensive", factory)).resolves.toBe("value");
+    await expect(cache.remember("expensive", factory)).resolves.toBe("value");
+
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Motivation
Provide a two-tier cache (in-process memory + optional Redis) to reduce latency on critical paths and enable shared, durable caching across instances.
Support configurable TTLs, namespace isolation, and LRU eviction so services can choose safe stale/refresh behavior per domain.
Ensure resilience by treating Redis as best-effort and exposing metrics for monitoring and alerting.
Description
Add src/services/redisCache.ts implementing RedisBackedCache with an in-process TTL memory tier, LRU eviction, JSON serialization, metrics (snapshotMetrics()), get/set/delete/remember APIs, and environment-driven defaults.
Add an Upstash REST adapter createUpstashRedisAdapter() and createCacheFromEnv() factory that wires UPSTASH_REDIS_REST_URL/UPSTASH_REDIS_REST_TOKEN plus CACHE_* settings and export systemCache.
Add operation and design docs in docs/redis-cache.md describing architecture, configuration keys, monitoring/alerts, deployment guidance, and runbook.
Add unit tests tests/unit/redisCache.test.ts covering TTL freshness/expiry, Redis hydration and namespacing, Redis-failure fallback behavior, Upstash REST command formatting, and remember() coalescing.
Testing
Ran unit tests with npx vitest run tests/unit/redisCache.test.ts, and all tests passed (6 passed).
Ran targeted linting with npx eslint src/services/redisCache.ts tests/unit/redisCache.test.ts which passed for the changed files.
Type-checking with npx tsc --noEmit completed successfully.
Note: running the full npm run lint still fails due to pre-existing unused-variable errors in src/components/map/AssetHeatmapLayer.tsx, which are outside these changes.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/115