### PR TITLE
Scheduled database backup

### DIFF
--- a/docs/runbooks/backup-verification.md
+++ b/docs/runbooks/backup-verification.md
@@ -1,0 +1,28 @@
+# Scheduled Database Backup Verification with Restore Testing
+
+## Architecture
+
+Every service publishes its database backup metadata to the verification runner after each scheduled backup. The runner restores the artifact into an isolated sandbox, replays migrations, validates row-count sentinels, and compares the restored checksum to the backup manifest before any backup is marked usable.
+
+## Monitoring and alerting
+
+Emit the metrics produced by `evaluateBackupRestore` for every service/database pair:
+
+- `backup_age_ms`
+- `restore_duration_ms`
+- `row_checks_total`
+- `findings_total`
+
+Page the owning service when a critical database returns `fail`, when `backup_age_ms` breaches the 24 hour policy, or when restore testing has not reported for two consecutive schedules. Route `warn` states to the platform operations channel for triage during business hours.
+
+## Deployment
+
+Deploy verification changes with blue-green infrastructure. Send 10% of service backup manifests to the green runner for the first canary window, compare pass/fail ratios and restore duration P99 against blue, then promote when no regression is observed.
+
+## Restore drill runbook
+
+1. Select the latest successful backup manifest for the service/database pair.
+2. Restore into the isolated verification sandbox with production network egress disabled.
+3. Replay migrations and seed required secrets from the recovery vault.
+4. Run row-count sentinels and checksum comparison.
+5. Record the result in the dashboard and attach findings to the incident if any check fails.

--- a/src/services/backupVerification.ts
+++ b/src/services/backupVerification.ts
@@ -1,0 +1,122 @@
+import {
+  BACKUP_VERIFICATION_VERSION,
+  DEFAULT_MAX_BACKUP_AGE_MS,
+  DEFAULT_RESTORE_RTO_MS,
+  type BackupServiceTarget,
+  type BackupVerificationFinding,
+  type BackupVerificationPolicy,
+  type BackupVerificationResult,
+  type BackupVerificationStatus,
+} from "@/types/backupVerification";
+
+const DEFAULT_POLICY: BackupVerificationPolicy = {
+  maxBackupAgeMs: DEFAULT_MAX_BACKUP_AGE_MS,
+  restoreRtoMs: DEFAULT_RESTORE_RTO_MS,
+  criticalRestoreRtoMs: 5 * 60 * 1000,
+};
+
+function worstStatus(findings: BackupVerificationFinding[]): BackupVerificationStatus {
+  if (findings.some((finding) => finding.severity === "fail")) return "fail";
+  if (findings.some((finding) => finding.severity === "warn")) return "warn";
+  return "pass";
+}
+
+export function evaluateBackupRestore(
+  target: BackupServiceTarget,
+  observedAt: number,
+  policy: Partial<BackupVerificationPolicy> = {}
+): BackupVerificationResult {
+  const effectivePolicy = { ...DEFAULT_POLICY, ...policy };
+  const restoreDurationMs = Math.max(
+    0,
+    target.restoreCompletedAt - target.restoreStartedAt
+  );
+  const backupAgeMs = Math.max(0, observedAt - target.backupCreatedAt);
+  const restoreBudgetMs =
+    target.criticality === "critical"
+      ? effectivePolicy.criticalRestoreRtoMs
+      : effectivePolicy.restoreRtoMs;
+  const findings: BackupVerificationFinding[] = [];
+
+  if (backupAgeMs > effectivePolicy.maxBackupAgeMs) {
+    findings.push({
+      code: "STALE_BACKUP",
+      severity: "fail",
+      message: `${target.service}/${target.database} latest backup is older than policy`,
+    });
+  }
+
+  if (restoreDurationMs > restoreBudgetMs) {
+    findings.push({
+      code: "RESTORE_RTO_EXCEEDED",
+      severity: target.criticality === "critical" ? "fail" : "warn",
+      message: `${target.service}/${target.database} restore exceeded ${restoreBudgetMs}ms RTO`,
+    });
+  }
+
+  for (const check of target.rowChecks) {
+    if (check.expected !== check.actual) {
+      findings.push({
+        code: "ROW_COUNT_MISMATCH",
+        severity: "fail",
+        message: `${check.table} expected ${check.expected} rows but restored ${check.actual}`,
+      });
+    }
+  }
+
+  if (!target.checksumMatches) {
+    findings.push({
+      code: "CHECKSUM_MISMATCH",
+      severity: "fail",
+      message: "Restored checksum does not match the backup manifest",
+    });
+  }
+
+  if (!target.migrationsApplied) {
+    findings.push({
+      code: "MIGRATION_REPLAY_FAILED",
+      severity: "fail",
+      message: "Migration replay failed in the restore sandbox",
+    });
+  }
+
+  return {
+    service: target.service,
+    database: target.database,
+    status: worstStatus(findings),
+    restoreDurationMs,
+    backupAgeMs,
+    findings,
+    metrics: {
+      backup_verification_version: Number(
+        BACKUP_VERIFICATION_VERSION.replace(".", "")
+      ),
+      backup_age_ms: backupAgeMs,
+      restore_duration_ms: restoreDurationMs,
+      row_checks_total: target.rowChecks.length,
+      findings_total: findings.length,
+    },
+  };
+}
+
+export function summarizeBackupFleet(results: BackupVerificationResult[]): {
+  status: BackupVerificationStatus;
+  total: number;
+  passing: number;
+  warning: number;
+  failing: number;
+  availabilityRiskServices: string[];
+} {
+  const failing = results.filter((result) => result.status === "fail");
+  const warning = results.filter((result) => result.status === "warn");
+  return {
+    status: failing.length > 0 ? "fail" : warning.length > 0 ? "warn" : "pass",
+    total: results.length,
+    passing: results.filter((result) => result.status === "pass").length,
+    warning: warning.length,
+    failing: failing.length,
+    availabilityRiskServices: failing.map(
+      (result) => `${result.service}/${result.database}`
+    ),
+  };
+}

--- a/src/types/backupVerification.ts
+++ b/src/types/backupVerification.ts
@@ -1,0 +1,46 @@
+export const BACKUP_VERIFICATION_VERSION = "2026.07";
+export const DEFAULT_RESTORE_RTO_MS = 15 * 60 * 1000;
+export const DEFAULT_MAX_BACKUP_AGE_MS = 24 * 60 * 60 * 1000;
+
+export type BackupCriticality = "critical" | "standard";
+export type BackupVerificationStatus = "pass" | "warn" | "fail";
+
+export interface BackupServiceTarget {
+  service: string;
+  database: string;
+  criticality: BackupCriticality;
+  scheduleCron: string;
+  backupCreatedAt: number;
+  restoreStartedAt: number;
+  restoreCompletedAt: number;
+  rowChecks: ReadonlyArray<{ table: string; expected: number; actual: number }>;
+  checksumMatches: boolean;
+  migrationsApplied: boolean;
+}
+
+export interface BackupVerificationPolicy {
+  maxBackupAgeMs: number;
+  restoreRtoMs: number;
+  criticalRestoreRtoMs: number;
+}
+
+export interface BackupVerificationFinding {
+  code:
+    | "STALE_BACKUP"
+    | "RESTORE_RTO_EXCEEDED"
+    | "ROW_COUNT_MISMATCH"
+    | "CHECKSUM_MISMATCH"
+    | "MIGRATION_REPLAY_FAILED";
+  severity: BackupVerificationStatus;
+  message: string;
+}
+
+export interface BackupVerificationResult {
+  service: string;
+  database: string;
+  status: BackupVerificationStatus;
+  restoreDurationMs: number;
+  backupAgeMs: number;
+  findings: BackupVerificationFinding[];
+  metrics: Record<string, number>;
+}

--- a/tests/unit/backupVerification.test.ts
+++ b/tests/unit/backupVerification.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { evaluateBackupRestore, summarizeBackupFleet } from "@/services/backupVerification";
+import type { BackupServiceTarget } from "@/types/backupVerification";
+
+const now = Date.UTC(2026, 6, 18, 12, 0, 0);
+
+function target(overrides: Partial<BackupServiceTarget> = {}): BackupServiceTarget {
+  return {
+    service: "billing",
+    database: "ledger",
+    criticality: "critical",
+    scheduleCron: "0 * * * *",
+    backupCreatedAt: now - 60_000,
+    restoreStartedAt: now - 30_000,
+    restoreCompletedAt: now - 5_000,
+    rowChecks: [{ table: "invoices", expected: 1200, actual: 1200 }],
+    checksumMatches: true,
+    migrationsApplied: true,
+    ...overrides,
+  };
+}
+
+describe("backup restore verification", () => {
+  it("passes a fresh backup with a complete restore rehearsal", () => {
+    const result = evaluateBackupRestore(target(), now);
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+    expect(result.metrics.restore_duration_ms).toBe(25_000);
+  });
+
+  it("fails stale backups and data integrity mismatches", () => {
+    const result = evaluateBackupRestore(
+      target({
+        backupCreatedAt: now - 48 * 60 * 60 * 1000,
+        rowChecks: [{ table: "payments", expected: 9, actual: 8 }],
+        checksumMatches: false,
+      }),
+      now
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings.map((finding) => finding.code)).toEqual([
+      "STALE_BACKUP",
+      "ROW_COUNT_MISMATCH",
+      "CHECKSUM_MISMATCH",
+    ]);
+  });
+
+  it("warns when a standard service restore exceeds RTO without integrity loss", () => {
+    const result = evaluateBackupRestore(
+      target({ criticality: "standard", restoreStartedAt: now - 20 * 60 * 1000 }),
+      now
+    );
+    expect(result.status).toBe("warn");
+    expect(result.findings[0]).toMatchObject({ code: "RESTORE_RTO_EXCEEDED", severity: "warn" });
+  });
+
+  it("summarizes fleet health for dashboards and alert routing", () => {
+    const passing = evaluateBackupRestore(target({ service: "gis" }), now);
+    const failing = evaluateBackupRestore(target({ service: "billing", checksumMatches: false }), now);
+    expect(summarizeBackupFleet([passing, failing])).toEqual({
+      status: "fail",
+      total: 2,
+      passing: 1,
+      warning: 0,
+      failing: 1,
+      availabilityRiskServices: ["billing/ledger"],
+    });
+  });
+});


### PR DESCRIPTION
Motivation
Implement a system-wide scheduled backup verification that performs restore rehearsals to ensure backups are fresh, restorable, and integrity-checked.
Provide machine-readable results and fleet-level summaries so monitoring, alerting, and dashboarding can route incidents and quantify availability risk.
Description
Add typed contracts in src/types/backupVerification.ts for targets, policy, findings, and results and expose version and default policy constants.
Implement evaluateBackupRestore and summarizeBackupFleet in src/services/backupVerification.ts which validate backup freshness, restore RTOs (with critical vs standard budgets), row-count sentinels, checksum equality, migration replay, and emit a small metrics payload per run.
Add unit tests in tests/unit/backupVerification.test.ts covering pass, fail, warn, and fleet-summary scenarios.
Add a runbook and deployment/monitoring guidance in docs/runbooks/backup-verification.md describing metrics to emit, alert routing, and a blue-green/canary deployment approach.
Testing
Ran npm test -- backupVerification.test.ts and all tests passed (4 tests, 1 file).
Ran npx eslint against the new files and npx tsc --noEmit, both succeeded for the added code.
npm run lint failed due to unrelated pre-existing AssetHeatmapLayer.tsx unused-variable errors, which are not introduced by this change.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/114