### PR TITLE
Kafka consumer lag monitoring

### DIFF
--- a/docs/kafka-consumer-lag-monitoring.md
+++ b/docs/kafka-consumer-lag-monitoring.md
@@ -1,0 +1,44 @@
+# Kafka Consumer Lag Monitoring and Auto-Scaling
+
+## Architecture
+
+1. **Lag collectors** poll Kafka committed offsets and broker high-watermarks for every production consumer group.
+2. **Policy evaluation** normalizes per-partition lag, groups by consumer group, and classifies health as `healthy`, `watch`, or `critical`.
+3. **Autoscaling adapters** convert lag summaries into bounded replica recommendations for KEDA/HPA controllers.
+4. **Observability** publishes `kafka_consumer_group_lag`, `kafka_consumer_group_lag_max_partition`, `kafka_consumer_group_lag_stale`, and `kafka_consumer_group_replicas_desired` metrics.
+5. **Operator dashboards** show backlog, max partition skew, stale telemetry, and the current scaling decision for each group.
+
+## Policy Defaults
+
+| Setting | Default | Purpose |
+| --- | ---: | --- |
+| Warning lag | 10,000 messages | Opens an investigation before SLO risk. |
+| Critical lag | 50,000 messages | Pages and triggers aggressive scale-out. |
+| Stale sample timeout | 120 seconds | Treats missing telemetry as critical. |
+| Minimum replicas | 2 | Keeps warm capacity for 99.99% availability. |
+| Maximum replicas | 30 | Protects downstream services and costs. |
+| Lag per replica | 5,000 messages | Backlog drained per replica inside the SLO window. |
+| Max scaling step | 4 replicas | Avoids oscillation during short spikes. |
+
+## Alerting
+
+- Page when a group remains `critical` for two consecutive evaluations or when lag telemetry is stale.
+- Warn when a group remains in `watch` for five minutes.
+- Create an incident when desired replicas equal the maximum and lag continues to rise.
+- Include topic, partition count, max partition lag, total lag, desired replicas, and current deployment color in every alert.
+
+## Blue-Green and Canary Rollout
+
+1. Deploy lag collectors and scaling adapters to the green environment with autoscaling in dry-run mode.
+2. Mirror Kafka offset samples from blue and compare recommendations for at least one business cycle.
+3. Enable canary scaling for one low-risk consumer group and verify P99 critical paths stay below 100 ms.
+4. Increase canary coverage to 25%, 50%, and 100% if lag recovery improves and error budgets remain healthy.
+5. Promote green only after dashboards, alerts, and rollback commands are verified.
+
+## Runbook
+
+1. Check whether lag samples are stale. If stale, inspect collector health and Kafka ACLs first.
+2. If lag is isolated to one partition, rebalance keys or split the hot partition before raising max replicas.
+3. If lag is system-wide, confirm downstream write latency and pause scale-out if dependencies are saturated.
+4. Use the recommendation helper in `src/utils/kafkaConsumerLag.ts` as the source of truth for manual replica overrides.
+5. Roll back to the previous deployment color if autoscaling increases errors or P99 latency exceeds 100 ms.

--- a/src/utils/kafkaConsumerLag.ts
+++ b/src/utils/kafkaConsumerLag.ts
@@ -1,0 +1,145 @@
+/**
+ * Kafka consumer-lag policy helpers shared by operations dashboards and
+ * auto-scaling controllers. The functions are deterministic and side-effect
+ * free so they can be reused by backend adapters, UI previews, and runbooks.
+ */
+
+export type LagSeverity = "healthy" | "watch" | "critical";
+
+export interface KafkaConsumerLagSample {
+  /** Consumer-group identifier. */
+  groupId: string;
+  /** Kafka topic name. */
+  topic: string;
+  /** Partition id inside the topic. */
+  partition: number;
+  /** Last committed offset for the consumer group. */
+  committedOffset: number;
+  /** Latest broker high-watermark offset. */
+  highWatermark: number;
+  /** Epoch millisecond timestamp when the sample was collected. */
+  sampledAt: number;
+}
+
+export interface LagPolicy {
+  /** Lag that should page operators and trigger aggressive scale-out. */
+  criticalLag: number;
+  /** Lag that should warn operators and allow moderate scale-out. */
+  warningLag: number;
+  /** Highest allowed lag age before the sample is considered stale. */
+  staleAfterMs: number;
+  /** Minimum replicas that the consumer group should keep warm. */
+  minReplicas: number;
+  /** Maximum replicas permitted by capacity and cost guardrails. */
+  maxReplicas: number;
+  /** Approximate backlog that a single replica can drain during the SLO window. */
+  lagPerReplica: number;
+  /** Replica count change allowed in a single evaluation tick. */
+  maxStep: number;
+}
+
+export interface ConsumerGroupLagSummary {
+  groupId: string;
+  totalLag: number;
+  maxPartitionLag: number;
+  partitions: number;
+  severity: LagSeverity;
+  stale: boolean;
+  sampledAt: number;
+}
+
+export interface ScalingRecommendation {
+  groupId: string;
+  currentReplicas: number;
+  desiredReplicas: number;
+  reason: string;
+  severity: LagSeverity;
+}
+
+export const DEFAULT_LAG_POLICY: LagPolicy = {
+  criticalLag: 50_000,
+  warningLag: 10_000,
+  staleAfterMs: 120_000,
+  minReplicas: 2,
+  maxReplicas: 30,
+  lagPerReplica: 5_000,
+  maxStep: 4,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function partitionLag(sample: KafkaConsumerLagSample): number {
+  if (!Number.isFinite(sample.committedOffset) || !Number.isFinite(sample.highWatermark)) {
+    throw new Error("Kafka offsets must be finite numbers");
+  }
+
+  return Math.max(0, Math.floor(sample.highWatermark - sample.committedOffset));
+}
+
+export function summarizeConsumerLag(
+  samples: KafkaConsumerLagSample[],
+  policy: LagPolicy = DEFAULT_LAG_POLICY,
+  now: number = Date.now()
+): ConsumerGroupLagSummary[] {
+  const byGroup = new Map<string, KafkaConsumerLagSample[]>();
+  for (const sample of samples) {
+    const groupSamples = byGroup.get(sample.groupId) ?? [];
+    groupSamples.push(sample);
+    byGroup.set(sample.groupId, groupSamples);
+  }
+
+  return Array.from(byGroup.entries())
+    .map(([groupId, groupSamples]) => {
+      const lags = groupSamples.map(partitionLag);
+      const totalLag = lags.reduce((sum, lag) => sum + lag, 0);
+      const maxPartitionLag = Math.max(...lags, 0);
+      const sampledAt = Math.max(...groupSamples.map((sample) => sample.sampledAt));
+      const stale = now - sampledAt > policy.staleAfterMs;
+      const severity: LagSeverity = stale || totalLag >= policy.criticalLag
+        ? "critical"
+        : totalLag >= policy.warningLag
+          ? "watch"
+          : "healthy";
+
+      return {
+        groupId,
+        totalLag,
+        maxPartitionLag,
+        partitions: groupSamples.length,
+        severity,
+        stale,
+        sampledAt,
+      };
+    })
+    .sort((a, b) => b.totalLag - a.totalLag || a.groupId.localeCompare(b.groupId));
+}
+
+export function recommendConsumerReplicas(
+  summary: ConsumerGroupLagSummary,
+  currentReplicas: number,
+  policy: LagPolicy = DEFAULT_LAG_POLICY
+): ScalingRecommendation {
+  if (policy.lagPerReplica <= 0) throw new Error("lagPerReplica must be positive");
+  const current = clamp(Math.round(currentReplicas), policy.minReplicas, policy.maxReplicas);
+  const backlogReplicas = Math.ceil(summary.totalLag / policy.lagPerReplica);
+  const target = clamp(Math.max(policy.minReplicas, backlogReplicas), policy.minReplicas, policy.maxReplicas);
+  const limitedTarget = target > current
+    ? Math.min(target, current + policy.maxStep)
+    : Math.max(target, current - policy.maxStep);
+
+  return {
+    groupId: summary.groupId,
+    currentReplicas: current,
+    desiredReplicas: limitedTarget,
+    severity: summary.severity,
+    reason: summary.stale
+      ? "lag metrics are stale; hold within guardrails while paging operators"
+      : limitedTarget > current
+        ? `scale out to drain ${summary.totalLag} queued messages`
+        : limitedTarget < current
+          ? `scale in after lag recovered to ${summary.totalLag}`
+          : `keep ${current} replicas for ${summary.totalLag} queued messages`,
+  };
+}

--- a/tests/unit/kafkaConsumerLag.test.ts
+++ b/tests/unit/kafkaConsumerLag.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LAG_POLICY,
+  partitionLag,
+  recommendConsumerReplicas,
+  summarizeConsumerLag,
+  type KafkaConsumerLagSample,
+} from "@/utils/kafkaConsumerLag";
+
+const baseSample: KafkaConsumerLagSample = {
+  groupId: "billing-writer",
+  topic: "meter-readings",
+  partition: 0,
+  committedOffset: 100,
+  highWatermark: 150,
+  sampledAt: 1_000,
+};
+
+describe("partitionLag", () => {
+  it("never reports negative lag when offsets race", () => {
+    expect(partitionLag({ ...baseSample, committedOffset: 200, highWatermark: 150 })).toBe(0);
+  });
+
+  it("rejects non-finite offsets", () => {
+    expect(() => partitionLag({ ...baseSample, committedOffset: Number.NaN })).toThrow(
+      "Kafka offsets must be finite numbers"
+    );
+  });
+});
+
+describe("summarizeConsumerLag", () => {
+  it("aggregates lag by consumer group and sorts the largest backlog first", () => {
+    const summaries = summarizeConsumerLag([
+      baseSample,
+      { ...baseSample, partition: 1, committedOffset: 0, highWatermark: 25 },
+      { ...baseSample, groupId: "notifications", committedOffset: 10, highWatermark: 15 },
+    ], DEFAULT_LAG_POLICY, 1_000);
+
+    expect(summaries).toEqual([
+      expect.objectContaining({
+        groupId: "billing-writer",
+        totalLag: 75,
+        maxPartitionLag: 50,
+        partitions: 2,
+        severity: "healthy",
+        stale: false,
+      }),
+      expect.objectContaining({ groupId: "notifications", totalLag: 5 }),
+    ]);
+  });
+
+  it("marks stale metrics as critical even with low lag", () => {
+    const [summary] = summarizeConsumerLag([baseSample], DEFAULT_LAG_POLICY, 125_001);
+
+    expect(summary.severity).toBe("critical");
+    expect(summary.stale).toBe(true);
+  });
+});
+
+describe("recommendConsumerReplicas", () => {
+  it("steps scale-out decisions instead of jumping straight to the target", () => {
+    const [summary] = summarizeConsumerLag([
+      { ...baseSample, committedOffset: 0, highWatermark: 80_000 },
+    ], DEFAULT_LAG_POLICY, 1_000);
+
+    expect(recommendConsumerReplicas(summary, 3)).toEqual({
+      groupId: "billing-writer",
+      currentReplicas: 3,
+      desiredReplicas: 7,
+      severity: "critical",
+      reason: "scale out to drain 80000 queued messages",
+    });
+  });
+
+  it("scales in only after lag has recovered", () => {
+    const [summary] = summarizeConsumerLag([baseSample], DEFAULT_LAG_POLICY, 1_000);
+
+    expect(recommendConsumerReplicas(summary, 12).desiredReplicas).toBe(8);
+  });
+});


### PR DESCRIPTION
Motivation
Provide deterministic, reusable helpers to summarize Kafka consumer-group lag and produce bounded autoscaling recommendations for dashboards and scaling adapters.
Encode operator guardrails (stale telemetry escalation, warning/critical thresholds, min/max replicas, and step limits) as a single authoritative policy.
Description
Add src/utils/kafkaConsumerLag.ts which defines types (KafkaConsumerLagSample, LagPolicy, ConsumerGroupLagSummary, ScalingRecommendation), DEFAULT_LAG_POLICY, and functions partitionLag, summarizeConsumerLag, and recommendConsumerReplicas implementing lag math, staleness detection, severity classification, and bounded scale decisions.
Add unit tests at tests/unit/kafkaConsumerLag.test.ts that cover offset validation, non-negative lag, group aggregation and sorting, stale escalation, scale-out step limiting, and scale-in behavior.
Add operational documentation docs/kafka-consumer-lag-monitoring.md describing architecture, default policy values, alerting, rollout guidance, and runbook usage.
Testing
Ran the new unit tests with npm test -- tests/unit/kafkaConsumerLag.test.ts, which passed (6 tests, 1 file).
Ran linting npm run lint -- src/utils/kafkaConsumerLag.ts tests/unit/kafkaConsumerLag.test.ts, which succeeded for the added files.
Ran the full test suite with npm test; this exercise surfaced unrelated, pre-existing test failures in other modules (AssetHeatmapLayer tile-key expectations and keyCache SHA-256 handling) that are not introduced by these changes.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/113