### PR TITLE
Webhook delivery service

### DIFF
--- a/docs/architecture/webhook-delivery.md
+++ b/docs/architecture/webhook-delivery.md
@@ -1,0 +1,56 @@
+# Webhook Delivery Service Architecture
+
+## Goals
+
+The webhook delivery service provides authenticated, observable event delivery to customer endpoints without adding synchronous latency to critical product paths.
+
+- **Critical path target:** enqueue webhook work in less than 100 ms P99; network delivery happens asynchronously.
+- **Availability target:** 99.99% service uptime through durable queues, idempotent workers, and blue-green deploys.
+- **Security target:** every request is signed with an HMAC-SHA256 signature and verified using constant-time comparison helpers.
+
+## Request flow
+
+1. Product services create a `WebhookEvent` after committing the source transaction.
+2. The event is persisted to a durable queue/outbox with endpoint metadata.
+3. Workers use `WebhookDeliveryService` to POST the stable JSON body to each endpoint.
+4. Each request includes `x-webhook-event-id`, `x-webhook-event-type`, `x-webhook-timestamp`, and `x-webhook-signature` headers.
+5. Non-2xx responses and transport errors are retried with capped exponential full-jitter backoff.
+6. Final failures are retained for operator review and customer replay tooling.
+
+## Signature contract
+
+The signature base string is:
+
+```text
+<ISO-8601 timestamp>.<stable JSON request body>
+```
+
+The `x-webhook-signature` header uses the format `v1=<hex hmac sha256>`. Consumers should reject requests when the timestamp is outside the configured replay window or `verifyWebhookSignature` returns false.
+
+## Retry policy
+
+Defaults are intentionally conservative:
+
+- maximum attempts: 5
+- base delay: 1 second
+- maximum delay: 60 seconds
+- jitter: full jitter to avoid synchronized retry storms
+
+Endpoint-specific overrides can lower or raise the attempt budget when required by customer contracts.
+
+## Monitoring and alerts
+
+Dashboards should track:
+
+- enqueue latency P50/P95/P99
+- delivery latency P50/P95/P99
+- success rate by endpoint and event type
+- retry count and final failure count
+- queue depth and oldest pending event age
+- signature verification failures reported by first-party receivers
+
+Alert when final failures exceed baseline, queue age breaches the SLO budget, or worker error rate indicates an availability risk.
+
+## Deployment
+
+Deploy workers with a blue-green strategy. Send a canary percentage of queued deliveries through the green pool, compare success rate and latency against blue, then gradually shift traffic. Roll back immediately on elevated final failures, signature mismatch spikes, or queue-age regression.

--- a/docs/runbooks/webhook-delivery.md
+++ b/docs/runbooks/webhook-delivery.md
@@ -1,0 +1,23 @@
+# Webhook Delivery Runbook
+
+## Triage checklist
+
+1. Check queue depth and oldest pending webhook age.
+2. Compare delivery success rate by endpoint, event type, and worker version.
+3. Inspect final failures for HTTP status patterns such as 401, 403, 429, or 5xx.
+4. Confirm recent deploy state and canary analysis results.
+5. Validate that endpoint secrets were not rotated without updating receivers.
+
+## Common remediations
+
+- **Customer endpoint outage:** pause the endpoint, notify the customer, and replay retained events after recovery.
+- **Elevated 429 responses:** reduce per-endpoint concurrency and let full-jitter retry smooth the backlog.
+- **Signature mismatches:** verify the shared secret, timestamp parsing, stable JSON body, and `v1=` signature format.
+- **Worker regression:** route traffic back to the blue pool, drain in-flight green deliveries, and open an incident review.
+
+## Security review notes
+
+- Secrets must be stored in managed secret storage and never logged.
+- Log event IDs and endpoint IDs, not payload bodies or signatures.
+- Signature verification must use constant-time comparison.
+- Replay protection should reject stale timestamps at receivers.

--- a/src/services/webhookDelivery.ts
+++ b/src/services/webhookDelivery.ts
@@ -1,0 +1,196 @@
+import { fullJitterBackoff } from "@/utils/backoff";
+
+export type WebhookEvent = {
+  id: string;
+  type: string;
+  createdAt: string;
+  payload: unknown;
+};
+
+export type WebhookEndpoint = {
+  id: string;
+  url: string;
+  secret: string;
+  maxAttempts?: number;
+};
+
+export type WebhookDeliveryStatus = "pending" | "delivered" | "retrying" | "failed";
+
+export type WebhookDeliveryAttempt = {
+  attempt: number;
+  status: WebhookDeliveryStatus;
+  statusCode?: number;
+  error?: string;
+  nextAttemptAt?: string;
+};
+
+export type WebhookDeliveryResult = {
+  eventId: string;
+  endpointId: string;
+  status: WebhookDeliveryStatus;
+  attempts: WebhookDeliveryAttempt[];
+};
+
+export type WebhookDeliveryOptions = {
+  fetcher?: typeof fetch;
+  now?: () => Date;
+  sleep?: (ms: number) => Promise<void>;
+  rng?: () => number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  defaultMaxAttempts?: number;
+};
+
+const SIGNATURE_VERSION = "v1";
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_BASE_DELAY_MS = 1_000;
+const DEFAULT_MAX_DELAY_MS = 60_000;
+
+const encoder = new TextEncoder();
+
+function toHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(",")}]`;
+  }
+
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, nested]) => `${JSON.stringify(key)}:${stableSerialize(nested)}`)
+    .join(",")}}`;
+}
+
+async function hmacSha256(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  return toHex(signature);
+}
+
+export function serializeWebhookEvent(event: WebhookEvent): string {
+  return stableSerialize(event);
+}
+
+export async function signWebhookPayload(
+  secret: string,
+  timestamp: string,
+  body: string
+): Promise<string> {
+  const digest = await hmacSha256(secret, `${timestamp}.${body}`);
+  return `${SIGNATURE_VERSION}=${digest}`;
+}
+
+export async function verifyWebhookSignature(
+  secret: string,
+  timestamp: string,
+  body: string,
+  signatureHeader: string
+): Promise<boolean> {
+  const expected = await signWebhookPayload(secret, timestamp, body);
+  const expectedBytes = encoder.encode(expected);
+  const actualBytes = encoder.encode(signatureHeader);
+
+  if (expectedBytes.length !== actualBytes.length) return false;
+
+  let diff = 0;
+  for (let index = 0; index < expectedBytes.length; index += 1) {
+    diff |= expectedBytes[index] ^ actualBytes[index];
+  }
+  return diff === 0;
+}
+
+export class WebhookDeliveryService {
+  private readonly fetcher: typeof fetch;
+  private readonly now: () => Date;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly rng: () => number;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly defaultMaxAttempts: number;
+
+  constructor(options: WebhookDeliveryOptions = {}) {
+    this.fetcher = options.fetcher ?? fetch;
+    this.now = options.now ?? (() => new Date());
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.rng = options.rng ?? Math.random;
+    this.baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+    this.maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+    this.defaultMaxAttempts = options.defaultMaxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  }
+
+  async deliver(event: WebhookEvent, endpoint: WebhookEndpoint): Promise<WebhookDeliveryResult> {
+    const body = serializeWebhookEvent(event);
+    const attempts: WebhookDeliveryAttempt[] = [];
+    const maxAttempts = endpoint.maxAttempts ?? this.defaultMaxAttempts;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const timestamp = this.now().toISOString();
+      const signature = await signWebhookPayload(endpoint.secret, timestamp, body);
+
+      try {
+        const response = await this.fetcher(endpoint.url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "user-agent": "utility-frontend-webhook-delivery/1.0",
+            "x-webhook-event-id": event.id,
+            "x-webhook-event-type": event.type,
+            "x-webhook-signature": signature,
+            "x-webhook-timestamp": timestamp,
+          },
+          body,
+        });
+
+        if (response.ok) {
+          attempts.push({ attempt, status: "delivered", statusCode: response.status });
+          return { eventId: event.id, endpointId: endpoint.id, status: "delivered", attempts };
+        }
+
+        const delay = attempt === maxAttempts ? undefined : this.retryDelay(attempt);
+        attempts.push({
+          attempt,
+          status: attempt === maxAttempts ? "failed" : "retrying",
+          statusCode: response.status,
+          nextAttemptAt: delay === undefined ? undefined : this.nextAttemptAt(delay),
+        });
+      } catch (error) {
+        const delay = attempt === maxAttempts ? undefined : this.retryDelay(attempt);
+        attempts.push({
+          attempt,
+          status: attempt === maxAttempts ? "failed" : "retrying",
+          error: error instanceof Error ? error.message : "Unknown webhook delivery error",
+          nextAttemptAt: delay === undefined ? undefined : this.nextAttemptAt(delay),
+        });
+      }
+
+      const lastAttempt = attempts.at(-1);
+      if (attempt < maxAttempts && lastAttempt?.nextAttemptAt) {
+        await this.sleep(new Date(lastAttempt.nextAttemptAt).getTime() - this.now().getTime());
+      }
+    }
+
+    return { eventId: event.id, endpointId: endpoint.id, status: "failed", attempts };
+  }
+
+  private retryDelay(attempt: number): number {
+    return fullJitterBackoff(attempt - 1, this.baseDelayMs, this.maxDelayMs, this.rng);
+  }
+
+  private nextAttemptAt(delayMs: number): string {
+    return new Date(this.now().getTime() + delayMs).toISOString();
+  }
+}

--- a/tests/unit/webhookDelivery.test.ts
+++ b/tests/unit/webhookDelivery.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WebhookDeliveryService,
+  serializeWebhookEvent,
+  signWebhookPayload,
+  verifyWebhookSignature,
+  type WebhookEvent,
+} from "@/services/webhookDelivery";
+
+const event: WebhookEvent = {
+  id: "evt_123",
+  type: "meter.reading.created",
+  createdAt: "2026-07-18T00:00:00.000Z",
+  payload: { z: 2, a: { c: true, b: "stable" } },
+};
+
+describe("webhook delivery signatures", () => {
+  it("serializes payloads deterministically", () => {
+    expect(serializeWebhookEvent(event)).toBe(
+      '{"createdAt":"2026-07-18T00:00:00.000Z","id":"evt_123","payload":{"a":{"b":"stable","c":true},"z":2},"type":"meter.reading.created"}'
+    );
+  });
+
+  it("signs and verifies HMAC-SHA256 payloads", async () => {
+    const body = serializeWebhookEvent(event);
+    const signature = await signWebhookPayload("secret", "2026-07-18T00:00:00.000Z", body);
+
+    expect(signature).toMatch(/^v1=[a-f0-9]{64}$/);
+    await expect(
+      verifyWebhookSignature("secret", "2026-07-18T00:00:00.000Z", body, signature)
+    ).resolves.toBe(true);
+    await expect(
+      verifyWebhookSignature("wrong", "2026-07-18T00:00:00.000Z", body, signature)
+    ).resolves.toBe(false);
+  });
+});
+
+describe("WebhookDeliveryService", () => {
+  it("delivers a signed POST request", async () => {
+    const fetcher = vi.fn(async () => new Response(null, { status: 204 }));
+    const service = new WebhookDeliveryService({
+      fetcher,
+      now: () => new Date("2026-07-18T00:00:00.000Z"),
+    });
+
+    const result = await service.deliver(event, {
+      id: "endpoint_1",
+      url: "https://example.com/webhook",
+      secret: "secret",
+    });
+
+    expect(result.status).toBe("delivered");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const [, init] = fetcher.mock.calls[0];
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({
+      "content-type": "application/json",
+      "x-webhook-event-id": "evt_123",
+      "x-webhook-event-type": "meter.reading.created",
+      "x-webhook-timestamp": "2026-07-18T00:00:00.000Z",
+    });
+    expect(String((init?.headers as Record<string, string>)["x-webhook-signature"])).toMatch(
+      /^v1=[a-f0-9]{64}$/
+    );
+  });
+
+  it("retries transient failures with jittered backoff and stops after max attempts", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(new Response(null, { status: 202 }));
+    const sleep = vi.fn(async () => undefined);
+    const service = new WebhookDeliveryService({
+      fetcher,
+      sleep,
+      rng: () => 0.5,
+      baseDelayMs: 1_000,
+      maxDelayMs: 10_000,
+      now: () => new Date("2026-07-18T00:00:00.000Z"),
+    });
+
+    const result = await service.deliver(event, {
+      id: "endpoint_1",
+      url: "https://example.com/webhook",
+      secret: "secret",
+      maxAttempts: 3,
+    });
+
+    expect(result.status).toBe("delivered");
+    expect(result.attempts.map((attempt) => attempt.status)).toEqual([
+      "retrying",
+      "retrying",
+      "delivered",
+    ]);
+    expect(sleep).toHaveBeenNthCalledWith(1, 500);
+    expect(sleep).toHaveBeenNthCalledWith(2, 1_000);
+  });
+
+  it("marks delivery failed after exhausting attempts", async () => {
+    const fetcher = vi.fn(async () => new Response(null, { status: 500 }));
+    const service = new WebhookDeliveryService({ fetcher, sleep: vi.fn(async () => undefined) });
+
+    const result = await service.deliver(event, {
+      id: "endpoint_1",
+      url: "https://example.com/webhook",
+      secret: "secret",
+      maxAttempts: 2,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.attempts.at(-1)).toMatchObject({ attempt: 2, status: "failed", statusCode: 500 });
+  });
+});


### PR DESCRIPTION
Motivation
Provide a system-wide webhook delivery mechanism that delivers authenticated, replay-protected events to customer endpoints with configurable retry budgets.
Ensure signatures are stable and verifiable by using deterministic serialization so receivers never see spurious signature mismatches.
Improve reliability under transient failures by applying capped exponential full-jitter backoff to avoid synchronized retry storms.
Description
Added src/services/webhookDelivery.ts which implements serializeWebhookEvent, signWebhookPayload, verifyWebhookSignature, and WebhookDeliveryService with configurable fetcher, now, sleep, rng, and retry/backoff behavior.
Uses HMAC-SHA256 with the v1=<hex> header format and a constant-time comparison for signature verification.
Uses a deterministic/stable JSON serializer and integrates fullJitterBackoff for jittered retry delays and next-attempt timestamps.
Added documentation and runbook at docs/architecture/webhook-delivery.md and docs/runbooks/webhook-delivery.md, and unit tests at tests/unit/webhookDelivery.test.ts covering serialization, signing/verification, signed POST delivery, retry behaviour, and exhausted-attempt failure handling.
Testing
Ran the new unit tests with npm test -- tests/unit/webhookDelivery.test.ts, which passed (all tests in that file succeeded).
Ran lint on the touched files with npm run lint -- src/services/webhookDelivery.ts tests/unit/webhookDelivery.test.ts, which completed without reported issues.
An attempted invocation using the Jest-style --runInBand flag (npm test -- --runInBand tests/unit/webhookDelivery.test.ts) failed because Vitest does not accept that flag.
Executing the full suite with npm test surfaced unrelated existing failures in tests/components/AssetHeatmapLayer.test.tsx and tests/unit/keyCache.test.ts, causing the overall suite to fail but not affecting the new unit tests for the webhook service.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/112