### PR TITLE
Postgre sql connection pool health probe

### DIFF
--- a/docs/postgres-pool-health.md
+++ b/docs/postgres-pool-health.md
@@ -1,0 +1,25 @@
+# PostgreSQL Connection Pool Health Probe with Adaptive Sizing
+
+## Architecture
+
+The health probe samples each service pool for active, idle, waiting, maximum connection count, probe latency, and probe error count. The shared policy in `src/services/postgresPoolHealth.ts` converts those snapshots into a service-wide status, alert severity, Prometheus-style metric names, and an adaptive max-connection recommendation.
+
+## Adaptive sizing policy
+
+- Keep critical-path probe latency below 100 ms P99.
+- Scale up by four connections when utilization reaches 70% or clients are waiting.
+- Scale down by two connections only when utilization is below 31.5%, no clients are waiting, and the cooldown has elapsed.
+- Clamp all recommendations between 4 and 80 connections to protect PostgreSQL from runaway clients.
+- Enforce a 30 second resize cooldown to prevent oscillation during short spikes.
+
+## Monitoring and alerting
+
+Emit the `metrics` map from every assessment to the metrics pipeline. Page on `critical`, warn on `degraded`, and annotate dashboard panels with the `reasons` list for operators.
+
+## Deployment runbook
+
+1. Deploy the probe in blue-green mode with recommendations logged but not applied.
+2. Canary one low-traffic service with adaptive resizing enabled.
+3. Compare P99 latency, waiting clients, and PostgreSQL server connection saturation for at least one business cycle.
+4. Enable adaptive sizing system-wide after security review confirms no credentials or SQL text are emitted.
+5. Roll back by disabling the adaptive apply flag; probes continue reporting health without resizing.

--- a/src/services/postgresPoolHealth.ts
+++ b/src/services/postgresPoolHealth.ts
@@ -1,0 +1,105 @@
+export type PoolHealthStatus = "healthy" | "degraded" | "critical";
+
+export interface PostgresPoolSnapshot {
+  activeConnections: number;
+  idleConnections: number;
+  waitingClients: number;
+  maxConnections: number;
+  probeLatencyMs: number;
+  errorCount: number;
+  timestamp: number;
+}
+
+export interface AdaptivePoolSizingPolicy {
+  minConnections: number;
+  maxConnections: number;
+  targetUtilization: number;
+  scaleUpStep: number;
+  scaleDownStep: number;
+  latencyBudgetMs: number;
+  waitingClientThreshold: number;
+  cooldownMs: number;
+}
+
+export interface PoolHealthAssessment {
+  status: PoolHealthStatus;
+  utilization: number;
+  recommendedMaxConnections: number;
+  reasons: string[];
+  alertSeverity: "none" | "warning" | "page";
+  metrics: Record<string, number>;
+}
+
+export const DEFAULT_POOL_SIZING_POLICY: AdaptivePoolSizingPolicy = {
+  minConnections: 4,
+  maxConnections: 80,
+  targetUtilization: 0.7,
+  scaleUpStep: 4,
+  scaleDownStep: 2,
+  latencyBudgetMs: 100,
+  waitingClientThreshold: 2,
+  cooldownMs: 30_000,
+};
+
+export function assessPostgresPoolHealth(
+  snapshot: PostgresPoolSnapshot,
+  policy: AdaptivePoolSizingPolicy = DEFAULT_POOL_SIZING_POLICY,
+  previousResizeAt = 0
+): PoolHealthAssessment {
+  const totalConnections = snapshot.activeConnections + snapshot.idleConnections;
+  const utilization = snapshot.maxConnections > 0 ? snapshot.activeConnections / snapshot.maxConnections : 1;
+  const reasons: string[] = [];
+  const canResize = snapshot.timestamp - previousResizeAt >= policy.cooldownMs;
+  let recommendedMaxConnections = clamp(snapshot.maxConnections, policy.minConnections, policy.maxConnections);
+
+  if (snapshot.probeLatencyMs > policy.latencyBudgetMs) {
+    reasons.push(`Probe latency ${snapshot.probeLatencyMs}ms exceeds ${policy.latencyBudgetMs}ms budget`);
+  }
+  if (snapshot.waitingClients > policy.waitingClientThreshold) {
+    reasons.push(`${snapshot.waitingClients} clients are waiting for a connection`);
+  }
+  if (snapshot.errorCount > 0) {
+    reasons.push(`${snapshot.errorCount} probe errors observed`);
+  }
+  if (utilization >= policy.targetUtilization || snapshot.waitingClients > 0) {
+    reasons.push(`Pool utilization is ${(utilization * 100).toFixed(1)}%`);
+    if (canResize) {
+      recommendedMaxConnections = clamp(
+        snapshot.maxConnections + policy.scaleUpStep,
+        policy.minConnections,
+        policy.maxConnections
+      );
+    }
+  } else if (utilization < policy.targetUtilization * 0.45 && snapshot.waitingClients === 0 && canResize) {
+    recommendedMaxConnections = clamp(
+      snapshot.maxConnections - policy.scaleDownStep,
+      policy.minConnections,
+      policy.maxConnections
+    );
+    reasons.push("Pool has sustained spare capacity and can scale down");
+  }
+
+  const critical = snapshot.errorCount >= 3 || snapshot.probeLatencyMs >= policy.latencyBudgetMs * 2;
+  const degraded = reasons.length > 0 || totalConnections > snapshot.maxConnections;
+
+  return {
+    status: critical ? "critical" : degraded ? "degraded" : "healthy",
+    utilization,
+    recommendedMaxConnections,
+    reasons: reasons.length > 0 ? reasons : ["Probe latency and pool pressure are within policy"],
+    alertSeverity: critical ? "page" : degraded ? "warning" : "none",
+    metrics: {
+      "postgres_pool_active_connections": snapshot.activeConnections,
+      "postgres_pool_idle_connections": snapshot.idleConnections,
+      "postgres_pool_waiting_clients": snapshot.waitingClients,
+      "postgres_pool_max_connections": snapshot.maxConnections,
+      "postgres_pool_probe_latency_ms": snapshot.probeLatencyMs,
+      "postgres_pool_utilization_ratio": utilization,
+      "postgres_pool_recommended_max_connections": recommendedMaxConnections,
+    },
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/tests/unit/postgresPoolHealth.test.ts
+++ b/tests/unit/postgresPoolHealth.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { assessPostgresPoolHealth, DEFAULT_POOL_SIZING_POLICY } from "@/services/postgresPoolHealth";
+
+const baseSnapshot = {
+  activeConnections: 8,
+  idleConnections: 4,
+  waitingClients: 0,
+  maxConnections: 20,
+  probeLatencyMs: 24,
+  errorCount: 0,
+  timestamp: 60_000,
+};
+
+describe("assessPostgresPoolHealth", () => {
+  it("reports healthy pools without changing size", () => {
+    const assessment = assessPostgresPoolHealth(baseSnapshot);
+
+    expect(assessment.status).toBe("healthy");
+    expect(assessment.alertSeverity).toBe("none");
+    expect(assessment.recommendedMaxConnections).toBe(20);
+  });
+
+  it("recommends scaling up under connection pressure", () => {
+    const assessment = assessPostgresPoolHealth({
+      ...baseSnapshot,
+      activeConnections: 18,
+      waitingClients: 3,
+    });
+
+    expect(assessment.status).toBe("degraded");
+    expect(assessment.alertSeverity).toBe("warning");
+    expect(assessment.recommendedMaxConnections).toBe(24);
+    expect(assessment.reasons.some((reason) => reason.includes("clients are waiting"))).toBe(true);
+  });
+
+  it("pages on repeated probe errors and respects the maximum bound", () => {
+    const assessment = assessPostgresPoolHealth({
+      ...baseSnapshot,
+      activeConnections: 78,
+      maxConnections: 80,
+      probeLatencyMs: 225,
+      errorCount: 3,
+    });
+
+    expect(assessment.status).toBe("critical");
+    expect(assessment.alertSeverity).toBe("page");
+    expect(assessment.recommendedMaxConnections).toBe(DEFAULT_POOL_SIZING_POLICY.maxConnections);
+  });
+
+  it("does not resize during cooldown", () => {
+    const assessment = assessPostgresPoolHealth(
+      { ...baseSnapshot, activeConnections: 18, waitingClients: 4 },
+      DEFAULT_POOL_SIZING_POLICY,
+      45_000
+    );
+
+    expect(assessment.recommendedMaxConnections).toBe(20);
+  });
+});


### PR DESCRIPTION
Motivation
Provide a shared, system-wide health probe that assesses PostgreSQL connection pools and emits a status, metrics, and bounded adaptive sizing recommendations to help meet latency and availability targets.
Capture operational guidance and a safe rollout strategy so operators can canary adaptive resizing and avoid oscillation or runaway connection growth.
Description
Add src/services/postgresPoolHealth.ts which defines snapshot and policy types, a DEFAULT_POOL_SIZING_POLICY, and assessPostgresPoolHealth that returns status (healthy|degraded|critical), an alert severity, Prometheus-style metric keys, a recommended max-connections value, and human-readable reasons, with cooldown and clamping applied.
Add docs/postgres-pool-health.md documenting architecture, the adaptive sizing policy, monitoring/alerting expectations, and a blue-green/canary deployment runbook.
Add unit tests in tests/unit/postgresPoolHealth.test.ts covering healthy, scale-up pressure, critical failure/max clamp, and cooldown behavior.
Ensure the assessment function is deterministic and safe by clamping recommendations and enforcing a configurable cooldown to prevent rapid oscillation.
Testing
Ran the focused unit tests with npx vitest --run tests/unit/postgresPoolHealth.test.ts, which passed.
Ran the full test suite with npm test; the run surfaced pre-existing unrelated failures in tests/components/AssetHeatmapLayer.test.tsx (tile-key expectations) and tests/unit/keyCache.test.ts (SubtleCrypto input handling), causing the global test run to fail.
Ran npm run lint, which failed due to pre-existing unused-variable errors in src/components/map/AssetHeatmapLayer.tsx and therefore did not block merging of the new unit tests.
Closes https://github.com/Utility-Protocol/utility-frontend/issues/109