### PR TITLE
Configuration management with hot reload and schema validation 

### DIFF
--- a/docs/configuration-management.md
+++ b/docs/configuration-management.md
@@ -1,0 +1,37 @@
+# Configuration Management Architecture
+
+## Goals
+
+- Validate every system-wide configuration update against a typed schema before it reaches application code.
+- Hot-reload accepted changes without a page reload or service restart.
+- Keep critical-path reads under the 100 ms P99 target by serving values from an in-memory snapshot.
+- Support 99.99% availability by rejecting bad payloads and retaining the last known-good configuration.
+
+## Design
+
+`ConfigManager` owns a versioned, immutable snapshot. Writers call `apply()` with partial updates. The manager merges the update over the active snapshot, adds schema defaults, validates the candidate, and atomically swaps it only when validation succeeds.
+
+Consumers read with `get()` or subscribe to hot-reload events. Subscribers receive the previous snapshot, current snapshot, changed keys, version, and apply timestamp. Polling sources can be connected through `createPoller()`, which is intentionally transport-agnostic so services can use REST, SSE, WebSocket, or edge-config providers.
+
+## Schema validation and security
+
+Each schema field declares a primitive type, optional default, required flag, custom validator, description, and sensitive flag. Sensitive values are redacted before logs, dashboards, or alert payloads are emitted.
+
+Rejected updates increment `config.validation_failed`, call the validation-error hook, and leave the active snapshot untouched. This protects uptime during bad deploys or compromised config pushes.
+
+## Monitoring and alerting
+
+Emit these metrics from the manager hooks:
+
+- `config.reload_latency_ms` with `result=success`; alert when P99 exceeds 100 ms for 5 minutes.
+- `config.validation_failed`; page on repeated failures from the same environment.
+- `config.version`; dashboard the latest accepted version per service.
+- Subscriber handler errors should be captured by the service-level error boundary or telemetry pipeline.
+
+## Deployment
+
+1. Deploy schema-only support dark-launched with the current static configuration as the initial snapshot.
+2. Enable polling for an internal canary cohort by setting `canaryPercent` above 0.
+3. Compare config reload latency, validation failure rate, and user-facing error rate between canary and control.
+4. Roll forward blue-green once canary metrics remain healthy for the agreed analysis window.
+5. Roll back by stopping the external config publisher; services keep the last known-good snapshot.

--- a/docs/runbooks/configuration-management.md
+++ b/docs/runbooks/configuration-management.md
@@ -1,0 +1,26 @@
+# Configuration Management Runbook
+
+## Symptoms
+
+- `config.validation_failed` increases.
+- Services report stale `config.version` values.
+- Hot-reload latency P99 exceeds 100 ms.
+
+## Triage
+
+1. Check the configuration dashboard for the latest accepted version by service and environment.
+2. Review validation-error logs. Sensitive fields must appear as `[REDACTED]`.
+3. Confirm the publisher delivered the same payload to canary and control services.
+4. If invalid payloads are recurring, pause the publisher and keep services on their last known-good snapshots.
+
+## Remediation
+
+- For schema mismatches, update the payload to satisfy the active schema and republish.
+- For latency regressions, reduce payload size or increase the polling interval for non-critical services.
+- For canary regressions, set `canaryPercent` to `0`, verify recovery, and restart the blue-green rollout after root cause is fixed.
+
+## Security review checklist
+
+- New fields have explicit types and validators.
+- Secrets are marked `sensitive` and verified redacted in logs and dashboards.
+- Config publishers authenticate and authorize updates out-of-band before payloads reach services.

--- a/src/services/configManager.ts
+++ b/src/services/configManager.ts
@@ -1,0 +1,196 @@
+export type ConfigPrimitive = string | number | boolean;
+export type ConfigValue = ConfigPrimitive | ConfigPrimitive[] | Record<string, ConfigPrimitive>;
+export type ConfigSnapshot = Record<string, ConfigValue>;
+
+export type ConfigFieldType = "string" | "number" | "boolean" | "string[]" | "number[]" | "record";
+
+export interface ConfigFieldSchema<T extends ConfigValue = ConfigValue> {
+  type: ConfigFieldType;
+  required?: boolean;
+  default?: T;
+  description?: string;
+  sensitive?: boolean;
+  validate?: (value: T, snapshot: ConfigSnapshot) => true | string;
+}
+
+export type ConfigSchema = Record<string, ConfigFieldSchema>;
+
+export interface ConfigChangeEvent {
+  version: number;
+  changedKeys: string[];
+  previous: Readonly<ConfigSnapshot>;
+  current: Readonly<ConfigSnapshot>;
+  appliedAt: number;
+}
+
+export interface ConfigValidationError {
+  key: string;
+  message: string;
+}
+
+export interface ConfigManagerOptions {
+  schema: ConfigSchema;
+  initial?: ConfigSnapshot;
+  now?: () => number;
+  onMetric?: (name: string, value: number, tags?: Record<string, string>) => void;
+  onValidationError?: (errors: ConfigValidationError[]) => void;
+}
+
+type ConfigListener = (event: ConfigChangeEvent) => void;
+
+type Poller = {
+  stop: () => void;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneSnapshot(snapshot: ConfigSnapshot): ConfigSnapshot {
+  return globalThis.structuredClone
+    ? globalThis.structuredClone(snapshot)
+    : JSON.parse(JSON.stringify(snapshot));
+}
+
+function matchesType(value: unknown, type: ConfigFieldType): boolean {
+  if (type === "string[]") return Array.isArray(value) && value.every((item) => typeof item === "string");
+  if (type === "number[]") return Array.isArray(value) && value.every((item) => typeof item === "number" && Number.isFinite(item));
+  if (type === "record") return isObject(value);
+  if (type === "number") return typeof value === "number" && Number.isFinite(value);
+  return typeof value === type;
+}
+
+export function redactConfig(snapshot: ConfigSnapshot, schema: ConfigSchema): ConfigSnapshot {
+  const redacted = cloneSnapshot(snapshot);
+  for (const [key, field] of Object.entries(schema)) {
+    if (field.sensitive && key in redacted) redacted[key] = "[REDACTED]";
+  }
+  return redacted;
+}
+
+export function validateConfig(snapshot: ConfigSnapshot, schema: ConfigSchema): ConfigValidationError[] {
+  const errors: ConfigValidationError[] = [];
+  for (const [key, field] of Object.entries(schema)) {
+    const value = snapshot[key] ?? field.default;
+    if (value === undefined) {
+      if (field.required) errors.push({ key, message: "is required" });
+      continue;
+    }
+    if (!matchesType(value, field.type)) {
+      errors.push({ key, message: `must be ${field.type}` });
+      continue;
+    }
+    const customResult = field.validate?.(value as never, snapshot);
+    if (typeof customResult === "string") errors.push({ key, message: customResult });
+  }
+  return errors;
+}
+
+export class ConfigManager {
+  private snapshot: ConfigSnapshot;
+  private version = 0;
+  private listeners = new Set<ConfigListener>();
+  private readonly schema: ConfigSchema;
+  private readonly now: () => number;
+  private readonly onMetric?: ConfigManagerOptions["onMetric"];
+  private readonly onValidationError?: ConfigManagerOptions["onValidationError"];
+
+  constructor(options: ConfigManagerOptions) {
+    this.schema = options.schema;
+    this.now = options.now ?? Date.now;
+    this.onMetric = options.onMetric;
+    this.onValidationError = options.onValidationError;
+    this.snapshot = this.withDefaults(options.initial ?? {});
+    const errors = validateConfig(this.snapshot, this.schema);
+    if (errors.length > 0) throw new Error(`Invalid initial configuration: ${errors.map((error) => `${error.key} ${error.message}`).join(", ")}`);
+  }
+
+  getVersion(): number {
+    return this.version;
+  }
+
+  getSnapshot(): Readonly<ConfigSnapshot> {
+    return cloneSnapshot(this.snapshot);
+  }
+
+  get<T extends ConfigValue>(key: string): T | undefined {
+    return cloneSnapshot(this.snapshot)[key] as T | undefined;
+  }
+
+  subscribe(listener: ConfigListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  apply(next: ConfigSnapshot): { ok: true; event: ConfigChangeEvent | null } | { ok: false; errors: ConfigValidationError[] } {
+    const startedAt = this.now();
+    const candidate = this.withDefaults({ ...this.snapshot, ...next });
+    const errors = validateConfig(candidate, this.schema);
+    if (errors.length > 0) {
+      this.onValidationError?.(errors);
+      this.onMetric?.("config.validation_failed", 1);
+      return { ok: false, errors };
+    }
+
+    const changedKeys = Object.keys(candidate).filter((key) => JSON.stringify(candidate[key]) !== JSON.stringify(this.snapshot[key]));
+    if (changedKeys.length === 0) return { ok: true, event: null };
+
+    const previous = cloneSnapshot(this.snapshot);
+    this.snapshot = candidate;
+    this.version += 1;
+    const event: ConfigChangeEvent = {
+      version: this.version,
+      changedKeys,
+      previous,
+      current: cloneSnapshot(this.snapshot),
+      appliedAt: this.now(),
+    };
+    this.onMetric?.("config.reload_latency_ms", Math.max(0, event.appliedAt - startedAt), { result: "success" });
+    for (const listener of this.listeners) listener(event);
+    return { ok: true, event };
+  }
+
+  createPoller(load: () => Promise<ConfigSnapshot>, intervalMs: number): Poller {
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const tick = async () => {
+      if (stopped) return;
+      try {
+        this.apply(await load());
+      } finally {
+        if (!stopped) timer = setTimeout(tick, intervalMs);
+      }
+    };
+    timer = setTimeout(tick, intervalMs);
+    return {
+      stop: () => {
+        stopped = true;
+        if (timer) clearTimeout(timer);
+      },
+    };
+  }
+
+  private withDefaults(snapshot: ConfigSnapshot): ConfigSnapshot {
+    const next = cloneSnapshot(snapshot);
+    for (const [key, field] of Object.entries(this.schema)) {
+      if (next[key] === undefined && field.default !== undefined) next[key] = field.default;
+    }
+    return next;
+  }
+}
+
+export const systemConfigSchema: ConfigSchema = {
+  apiBaseUrl: { type: "string", required: true, description: "Base API URL used by service clients." },
+  apiTimeoutMs: {
+    type: "number",
+    default: 15_000,
+    validate: (value) => (Number(value) > 0 && Number(value) <= 60_000 ? true : "must be between 1 and 60000"),
+  },
+  enableTelemetry: { type: "boolean", default: true },
+  canaryPercent: {
+    type: "number",
+    default: 0,
+    validate: (value) => (Number(value) >= 0 && Number(value) <= 100 ? true : "must be between 0 and 100"),
+  },
+  alertWebhookUrl: { type: "string", required: false, sensitive: true },
+};

--- a/tests/unit/configManager.test.ts
+++ b/tests/unit/configManager.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConfigManager, redactConfig, systemConfigSchema, validateConfig, type ConfigSchema } from "@/services/configManager";
+
+const schema: ConfigSchema = {
+  endpoint: { type: "string", required: true },
+  timeoutMs: { type: "number", default: 100, validate: (value) => (Number(value) < 1_000 ? true : "is too high") },
+  enabled: { type: "boolean", default: true },
+  token: { type: "string", sensitive: true },
+};
+
+describe("validateConfig", () => {
+  it("applies required, type, and custom validation rules", () => {
+    expect(validateConfig({ endpoint: "https://api.example", timeoutMs: 500 }, schema)).toEqual([]);
+    expect(validateConfig({ timeoutMs: 1_500, enabled: "yes" as never }, schema)).toEqual([
+      { key: "endpoint", message: "is required" },
+      { key: "timeoutMs", message: "is too high" },
+      { key: "enabled", message: "must be boolean" },
+    ]);
+  });
+});
+
+describe("ConfigManager", () => {
+  it("hydrates defaults and exposes immutable snapshots", () => {
+    const manager = new ConfigManager({ schema, initial: { endpoint: "local" } });
+    const snapshot = manager.getSnapshot();
+    expect(snapshot).toMatchObject({ endpoint: "local", timeoutMs: 100, enabled: true });
+
+    (snapshot as Record<string, unknown>).endpoint = "mutated";
+    expect(manager.get("endpoint")).toBe("local");
+  });
+
+  it("hot-reloads valid changes and notifies subscribers", () => {
+    const onMetric = vi.fn();
+    const manager = new ConfigManager({ schema, initial: { endpoint: "v1" }, now: () => 10, onMetric });
+    const listener = vi.fn();
+    manager.subscribe(listener);
+
+    const result = manager.apply({ endpoint: "v2", token: "secret" });
+
+    expect(result.ok).toBe(true);
+    expect(manager.getVersion()).toBe(1);
+    expect(manager.get("endpoint")).toBe("v2");
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ changedKeys: ["endpoint", "token"], version: 1 }));
+    expect(onMetric).toHaveBeenCalledWith("config.reload_latency_ms", 0, { result: "success" });
+  });
+
+  it("rejects invalid hot-reload payloads without changing active config", () => {
+    const onValidationError = vi.fn();
+    const manager = new ConfigManager({ schema, initial: { endpoint: "v1" }, onValidationError });
+
+    const result = manager.apply({ timeoutMs: 2_000 });
+
+    expect(result.ok).toBe(false);
+    expect(manager.get("timeoutMs")).toBe(100);
+    expect(manager.getVersion()).toBe(0);
+    expect(onValidationError).toHaveBeenCalledWith([{ key: "timeoutMs", message: "is too high" }]);
+  });
+
+  it("polls an async source for new configuration until stopped", async () => {
+    vi.useFakeTimers();
+    const manager = new ConfigManager({ schema, initial: { endpoint: "v1" } });
+    const load = vi.fn().mockResolvedValue({ endpoint: "v2" });
+
+    const poller = manager.createPoller(load, 250);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(manager.get("endpoint")).toBe("v2");
+
+    poller.stop();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(load).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});
+
+describe("systemConfigSchema", () => {
+  it("documents production safety bounds", () => {
+    expect(validateConfig({ apiBaseUrl: "https://api.example", canaryPercent: 101 }, systemConfigSchema)).toEqual([
+      { key: "canaryPercent", message: "must be between 0 and 100" },
+    ]);
+  });
+
+  it("redacts sensitive fields for logs and dashboards", () => {
+    expect(redactConfig({ apiBaseUrl: "x", alertWebhookUrl: "secret" }, systemConfigSchema)).toEqual({
+      apiBaseUrl: "x",
+      alertWebhookUrl: "[REDACTED]",
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a system-wide, versioned configuration service that validates updates against a typed schema and hot-reloads accepted changes without service restarts.
- Ensure safety and availability by rejecting invalid payloads, emitting validation/latency metrics, and keeping a last known-good snapshot for reads under the P99 100 ms target.
- Make sensitive fields safe for logs/dashboards by supporting `sensitive` schema flags and redaction.

### Description
- Add `src/services/configManager.ts` which implements a typed `ConfigManager` class, `validateConfig`, `redactConfig`, immutable snapshots, subscriber events, `createPoller()` for async polling sources, and metric/validation hooks, with numeric validators coerced via `Number()` for type safety.
- Add `tests/unit/configManager.test.ts` covering validation rules, default hydration, immutable snapshots, hot-reload notifications, rejection behavior, polling, production safety bounds, and redaction.
- Add architecture docs `docs/configuration-management.md` and an operational runbook `docs/runbooks/configuration-management.md` describing design, monitoring, rollout (blue-green/canary), and remediation steps.

### Testing
- Ran unit tests with `vitest` for the new test file and all tests passed (`1 file`, `7 tests`).
- Type-checked the code with `npx tsc --noEmit` which succeeded.
- Linted the new service and test with `npx eslint src/services/configManager.ts tests/unit/configManager.test.ts` which succeeded for the added files, while a full `npm run lint` still fails due to pre-existing unused variables in `src/components/map/AssetHeatmapLayer.tsx`.
- `npm run build` failed in this environment due to network/font fetch errors from Google Fonts during the Next.js build, which is unrelated to the new configuration manager implementation.

------

Closes #121