### PR TITLE
Dead letter queue for failed message processing

### DIFF
--- a/docs/dead-letter-queue.md
+++ b/docs/dead-letter-queue.md
@@ -1,0 +1,52 @@
+# Dead Letter Queue for Failed Message Processing
+
+## Architecture
+
+The frontend message-processing boundary uses `DeadLetterQueue` as the shared guard for messages that cannot be handled successfully after a bounded retry budget. Each message carries an id, type, payload, optional priority, and optional trace id so failures can be correlated with backend logs and alert events.
+
+Processing flow:
+
+1. Handle a message through the registered service-specific handler.
+2. Track attempts per message id and return `retryable-failure` until the retry budget is exhausted.
+3. Move exhausted messages into the dead-letter collection with failure reason, attempt count, failed timestamp, retryability, and trace metadata.
+4. Expose metrics for queue depth, retries, dead-letter count, evictions, and critical-path P99 latency.
+5. Replay remediated records through the same handler path so fixes do not bypass validation.
+
+## Operational Targets
+
+- Critical path P99 is measured for `priority: "critical"` messages and should remain under 100 ms.
+- Queue metrics should be bridged to the production telemetry sink by the service composing `DeadLetterQueue` via `onMetric`.
+- The queue has bounded capacity to protect availability; oldest records are evicted when capacity is reached and the dropped counter increments.
+
+## Alerts and Dashboards
+
+Recommended dashboard panels:
+
+- Dead-letter queue depth by service and message type.
+- Retry rate and dead-letter rate over five-minute windows.
+- Dropped dead-letter records caused by queue capacity pressure.
+- Critical-path P99 latency with a 100 ms threshold line.
+
+Recommended alerts:
+
+- Page when critical-path P99 is above 100 ms for 10 minutes.
+- Page when dead-letter depth grows for three consecutive windows.
+- Ticket when any dropped dead-letter records are observed.
+
+## Deployment Plan
+
+Use a blue-green deployment with canary analysis:
+
+1. Deploy the new queue path disabled or shadowed in blue.
+2. Enable the canary for low-volume message types and compare retry/dead-letter rates against green.
+3. Expand to critical message types once P99 remains below 100 ms and no dropped records are observed.
+4. Promote blue after dashboard parity and alert health are confirmed.
+5. Keep the previous path available for rollback until one full business cycle completes.
+
+## Runbook
+
+1. Open the dead-letter dashboard and identify message types with growing depth.
+2. Inspect the record reason and trace id to locate the upstream or handler failure.
+3. Fix the underlying schema, payload, network, or handler problem.
+4. Replay a small sample through `replayDeadLetter` and confirm the records leave the queue.
+5. Replay the remaining affected records and monitor P99 latency plus dropped count.

--- a/src/services/deadLetterQueue.ts
+++ b/src/services/deadLetterQueue.ts
@@ -1,0 +1,185 @@
+export type MessagePriority = "critical" | "standard" | "bulk";
+
+export interface ProcessableMessage<TPayload = unknown> {
+  id: string;
+  type: string;
+  payload: TPayload;
+  priority?: MessagePriority;
+  createdAt?: number;
+  traceId?: string;
+}
+
+export interface FailedMessageRecord<TPayload = unknown>
+  extends ProcessableMessage<TPayload> {
+  failedAt: number;
+  attempts: number;
+  reason: string;
+  retryable: boolean;
+}
+
+export interface DeadLetterQueueMetrics {
+  queued: number;
+  processed: number;
+  retried: number;
+  deadLettered: number;
+  dropped: number;
+  p99CriticalPathMs: number;
+}
+
+export interface DeadLetterQueueOptions {
+  maxAttempts?: number;
+  maxDeadLetters?: number;
+  now?: () => number;
+  onMetric?: (metrics: DeadLetterQueueMetrics) => void;
+}
+
+export type MessageHandler<TPayload = unknown> = (
+  message: ProcessableMessage<TPayload>
+) => Promise<void> | void;
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_MAX_DEAD_LETTERS = 1_000;
+
+function errorReason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function percentile99(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.99) - 1);
+  return sorted[index];
+}
+
+export class DeadLetterQueue<TPayload = unknown> {
+  private readonly maxAttempts: number;
+  private readonly maxDeadLetters: number;
+  private readonly now: () => number;
+  private readonly onMetric?: (metrics: DeadLetterQueueMetrics) => void;
+  private readonly deadLetters = new Map<string, FailedMessageRecord<TPayload>>();
+  private readonly attempts = new Map<string, number>();
+  private readonly criticalPathDurations: number[] = [];
+  private processed = 0;
+  private retried = 0;
+  private dropped = 0;
+
+  constructor(options: DeadLetterQueueOptions = {}) {
+    this.maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.maxDeadLetters = options.maxDeadLetters ?? DEFAULT_MAX_DEAD_LETTERS;
+    this.now = options.now ?? Date.now;
+    this.onMetric = options.onMetric;
+  }
+
+  async process(
+    message: ProcessableMessage<TPayload>,
+    handler: MessageHandler<TPayload>
+  ): Promise<"processed" | "retryable-failure" | "dead-lettered"> {
+    const startedAt = this.now();
+    try {
+      await handler(message);
+      this.processed += 1;
+      this.attempts.delete(message.id);
+      this.recordDuration(message, startedAt);
+      this.emitMetrics();
+      return "processed";
+    } catch (error) {
+      this.recordDuration(message, startedAt);
+      const attempts = (this.attempts.get(message.id) ?? 0) + 1;
+      this.attempts.set(message.id, attempts);
+
+      if (attempts < this.maxAttempts) {
+        this.retried += 1;
+        this.emitMetrics();
+        return "retryable-failure";
+      }
+
+      this.deadLetter(message, attempts, errorReason(error), true);
+      this.attempts.delete(message.id);
+      return "dead-lettered";
+    }
+  }
+
+  deadLetter(
+    message: ProcessableMessage<TPayload>,
+    attempts: number,
+    reason: string,
+    retryable = false
+  ): FailedMessageRecord<TPayload> {
+    if (this.deadLetters.size >= this.maxDeadLetters) {
+      const oldestKey = this.deadLetters.keys().next().value as string | undefined;
+      if (oldestKey) {
+        this.deadLetters.delete(oldestKey);
+        this.dropped += 1;
+      }
+    }
+
+    const record: FailedMessageRecord<TPayload> = {
+      ...message,
+      createdAt: message.createdAt ?? this.now(),
+      failedAt: this.now(),
+      attempts,
+      reason,
+      retryable,
+    };
+    this.deadLetters.set(message.id, record);
+    this.emitMetrics();
+    return record;
+  }
+
+  listDeadLetters(): FailedMessageRecord<TPayload>[] {
+    return [...this.deadLetters.values()].sort((a, b) => a.failedAt - b.failedAt);
+  }
+
+  getDeadLetter(id: string): FailedMessageRecord<TPayload> | undefined {
+    return this.deadLetters.get(id);
+  }
+
+  removeDeadLetter(id: string): boolean {
+    const removed = this.deadLetters.delete(id);
+    if (removed) this.emitMetrics();
+    return removed;
+  }
+
+  async replayDeadLetter(
+    id: string,
+    handler: MessageHandler<TPayload>
+  ): Promise<"processed" | "dead-lettered" | "missing"> {
+    const record = this.deadLetters.get(id);
+    if (!record) return "missing";
+
+    const startedAt = this.now();
+    try {
+      await handler(record);
+      this.deadLetters.delete(id);
+      this.processed += 1;
+      this.recordDuration(record, startedAt);
+      this.emitMetrics();
+      return "processed";
+    } catch (error) {
+      this.recordDuration(record, startedAt);
+      this.deadLetter(record, record.attempts + 1, errorReason(error), true);
+      return "dead-lettered";
+    }
+  }
+
+  metrics(): DeadLetterQueueMetrics {
+    return {
+      queued: this.deadLetters.size,
+      processed: this.processed,
+      retried: this.retried,
+      deadLettered: this.deadLetters.size,
+      dropped: this.dropped,
+      p99CriticalPathMs: percentile99(this.criticalPathDurations),
+    };
+  }
+
+  private recordDuration(message: ProcessableMessage<TPayload>, startedAt: number): void {
+    if (message.priority !== "critical") return;
+    this.criticalPathDurations.push(Math.max(0, this.now() - startedAt));
+    if (this.criticalPathDurations.length > 256) this.criticalPathDurations.shift();
+  }
+
+  private emitMetrics(): void {
+    this.onMetric?.(this.metrics());
+  }
+}

--- a/tests/unit/deadLetterQueue.test.ts
+++ b/tests/unit/deadLetterQueue.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeadLetterQueue, type ProcessableMessage } from "@/services/deadLetterQueue";
+
+const message: ProcessableMessage<{ value: number }> = {
+  id: "meter-1:reading-1",
+  type: "meter.reading.ingested",
+  payload: { value: 42 },
+  priority: "critical",
+  traceId: "trace-123",
+};
+
+describe("DeadLetterQueue", () => {
+  it("dead-letters a message after the configured retry budget is exhausted", async () => {
+    let now = 1_000;
+    const metrics = vi.fn();
+    const queue = new DeadLetterQueue({ maxAttempts: 2, now: () => (now += 10), onMetric: metrics });
+    const handler = vi.fn().mockRejectedValue(new Error("schema validation failed"));
+
+    await expect(queue.process(message, handler)).resolves.toBe("retryable-failure");
+    await expect(queue.process(message, handler)).resolves.toBe("dead-lettered");
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(queue.listDeadLetters()).toEqual([
+      expect.objectContaining({
+        id: message.id,
+        attempts: 2,
+        reason: "schema validation failed",
+        retryable: true,
+        traceId: "trace-123",
+      }),
+    ]);
+    expect(queue.metrics()).toMatchObject({ queued: 1, retried: 1, deadLettered: 1 });
+    expect(queue.metrics().p99CriticalPathMs).toBe(10);
+    expect(metrics).toHaveBeenCalled();
+  });
+
+  it("removes retry state after successful processing", async () => {
+    const queue = new DeadLetterQueue({ maxAttempts: 2 });
+    await expect(queue.process(message, vi.fn().mockRejectedValue("temporary outage"))).resolves.toBe(
+      "retryable-failure"
+    );
+    await expect(queue.process(message, vi.fn())).resolves.toBe("processed");
+    await expect(queue.process(message, vi.fn().mockRejectedValue("new failure"))).resolves.toBe(
+      "retryable-failure"
+    );
+
+    expect(queue.listDeadLetters()).toHaveLength(0);
+  });
+
+  it("replays and removes a dead-lettered message when remediation succeeds", async () => {
+    const queue = new DeadLetterQueue<{ value: number }>({ maxAttempts: 1 });
+    queue.deadLetter(message, 3, "downstream 500", true);
+
+    await expect(queue.replayDeadLetter(message.id, vi.fn())).resolves.toBe("processed");
+
+    expect(queue.getDeadLetter(message.id)).toBeUndefined();
+    expect(queue.metrics()).toMatchObject({ queued: 0, processed: 1 });
+  });
+
+  it("keeps a dead-lettered message when replay still fails", async () => {
+    const queue = new DeadLetterQueue<{ value: number }>({ maxAttempts: 1 });
+    queue.deadLetter(message, 3, "downstream 500", true);
+
+    await expect(
+      queue.replayDeadLetter(message.id, vi.fn().mockRejectedValue(new Error("still down")))
+    ).resolves.toBe("dead-lettered");
+
+    expect(queue.getDeadLetter(message.id)).toEqual(
+      expect.objectContaining({ attempts: 4, reason: "still down" })
+    );
+  });
+
+  it("evicts the oldest dead letter when capacity is reached", () => {
+    let now = 0;
+    const queue = new DeadLetterQueue({ maxDeadLetters: 2, now: () => ++now });
+
+    queue.deadLetter({ ...message, id: "a" }, 1, "a");
+    queue.deadLetter({ ...message, id: "b" }, 1, "b");
+    queue.deadLetter({ ...message, id: "c" }, 1, "c");
+
+    expect(queue.listDeadLetters().map((record) => record.id)).toEqual(["b", "c"]);
+    expect(queue.metrics().dropped).toBe(1);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a system-wide, frontend-side guard for messages that cannot be processed after a bounded retry budget so failures are observable and remediable. 
- Track critical-path latency and surface metrics to meet the P99 performance target and protect availability with bounded capacity and eviction.

### Description

- Add `DeadLetterQueue` implementation in `src/services/deadLetterQueue.ts` with `process`, `deadLetter`, `replayDeadLetter`, `listDeadLetters`, `getDeadLetter`, `removeDeadLetter`, and `metrics` APIs. 
- Support bounded retry budgets, per-message attempt tracking, dead-letter record metadata (reason, attempts, failedAt, traceId), capacity eviction of oldest records, and critical-path P99 latency sampling for `priority: "critical"` messages. 
- Add operational documentation in `docs/dead-letter-queue.md` describing architecture, targets, dashboards, alerts, deployment plan, and runbook. 
- Add unit tests in `tests/unit/deadLetterQueue.test.ts` covering retry exhaustion, retry-state reset after success, replay success, replay failure retention, and capacity eviction.

### Testing

- Ran unit tests with `npm test -- tests/unit/deadLetterQueue.test.ts` and all tests passed (`1 file, 5 tests, 5 passed`).
- Type-checking with `npx tsc --noEmit` succeeded.
- `npm run lint` failed due to existing unrelated lint errors in `src/components/map/AssetHeatmapLayer.tsx` (unused variables), not introduced by this change. 
- `npm run build` failed in this environment because `next/font` could not fetch Google Fonts from `fonts.googleapis.com`, which is an external-network issue during the build step.

------

Closes  #119