### PR TITLE
a11y: add WCAG 2.1 accessibility statement + tighten axe gate to moderate

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,0 +1,66 @@
+# Accessibility Statement
+
+Utility Protocol is committed to making its operator dashboard usable by everyone,
+including people who rely on assistive technology.
+
+## Conformance target
+
+**WCAG 2.1 Level AA.** We measure against the `wcag2a`, `wcag2aa`, `wcag21a`, and
+`wcag21aa` rule sets.
+
+## Current status
+
+As of the latest audit, the application has **no automated accessibility violations** at
+**critical, serious, or moderate** impact on the audited routes:
+
+| Route | axe-core (WCAG 2.1 AA) | Keyboard navigation |
+|---|---|---|
+| `/` (operator dashboard) | ✅ 0 violations (all severities) | ✅ reachable, no traps |
+| `/export` | ✅ 0 violations (all severities) | ✅ reachable |
+
+The dashboard is composed of `GracefulDegradationDashboard`, `SloMonitoringPanel`,
+`DisasterRecoveryPanel`, and the spatial grid views, all rendered at `/`.
+
+## How accessibility is tested
+
+Testing is automated and runs on demand via Playwright:
+
+```bash
+npm run test:a11y
+```
+
+This runs two suites in `tests/a11y/`:
+
+- **`axe-core` audit** (`axe.spec.ts`) — scans each route against WCAG 2.1 A/AA and fails
+  the build on any **critical, serious, or moderate** violation.
+- **Keyboard navigation** (`keyboard.spec.ts`) — verifies header controls are reachable by
+  `Tab`, that tabbing reaches multiple distinct elements without a focus trap, and that the
+  theme toggle is operable by keyboard.
+
+These suites are **enforced in CI** by `.github/workflows/a11y.yml`, which runs them via
+`playwright.a11y.config.ts` on every change, so an accessibility regression fails the
+build. `npm run test:a11y` runs the same suites locally.
+
+## Accessibility measures in the codebase
+
+- `lang="en"` set on the root `<html>` element (`src/app/layout.tsx`).
+- Semantic, native interactive elements (buttons, selects) with ARIA names — no
+  non-semantic `<div onClick>` interactive controls.
+- Visible focus indicators (`:focus-visible` / focus-ring styles).
+- Theme system with light/dark modes chosen for adequate contrast.
+- Loading skeletons carry visible text rather than being empty regions.
+
+## Known limitations
+
+- **Manual screen-reader verification** (VoiceOver / NVER) is not automated; automated
+  tooling cannot fully substitute for it. Reviewers should spot-check new interactive
+  panels with a screen reader.
+- Map / canvas-based visualizations (`GridMap`, `FleetGrid`) convey spatial data that is
+  inherently visual; they are accompanied by textual data elsewhere on the page, but a
+  fully equivalent non-visual experience is an ongoing effort.
+
+## Feedback
+
+If you encounter an accessibility barrier, please open an issue on the repository with the
+route, the assistive technology used, and a short description. Accessibility regressions
+should be reported the same way and are treated as bugs.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:visual": "npx playwright test tests/visual",
+    "test:a11y": "npx playwright test --config=playwright.a11y.config.ts",
     "visual:update-baselines": "npx tsx scripts/update-baselines.ts",
     "test:coverage": "vitest --run --coverage.enabled --coverage.provider=v8",
     "test:coverage:ci": "vitest --run --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov"

--- a/tests/a11y/axe.spec.ts
+++ b/tests/a11y/axe.spec.ts
@@ -5,7 +5,7 @@ const SCAN_PATHS = ["/", "/export"];
 
 test.describe("axe-core accessibility audit", () => {
   for (const path of SCAN_PATHS) {
-    test(`no critical or serious violations on ${path}`, async ({ page }) => {
+    test(`no critical, serious, or moderate violations on ${path}`, async ({ page }) => {
       await page.goto(path, { waitUntil: "load", timeout: 60_000 });
       await page.waitForTimeout(2_000);
       await page.addScriptTag({ content: axe.source });
@@ -18,11 +18,14 @@ test.describe("axe-core accessibility audit", () => {
             values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
           },
         });
+        // Gate on critical, serious, AND moderate impact. The dashboard
+        // currently reports zero violations at any level (see
+        // docs/ACCESSIBILITY.md); moderate is included so a regression that
+        // introduces a moderate WCAG issue also fails the build, not just
+        // critical/serious ones.
+        const blocking = new Set(["critical", "serious", "moderate"]);
         return results.violations
-          .filter(
-            (violation) =>
-              violation.impact === "critical" || violation.impact === "serious"
-          )
+          .filter((violation) => blocking.has(violation.impact ?? ""))
           .map((violation) => ({
             id: violation.id,
             impact: violation.impact,


### PR DESCRIPTION
## Summary

Accessibility audit for the operator dashboard (`/`), against WCAG 2.1 AA.

**Audit result:** the dashboard is already in good shape. axe-core reports **zero WCAG 2.1 A/AA violations at any severity** on `/` and `/export`, keyboard navigation passes, and — importantly — this is **already enforced in CI** by `.github/workflows/a11y.yml`, which runs the axe + keyboard suites via `playwright.a11y.config.ts`. So there are **no critical or serious violations to fix**.

The one acceptance-criteria item that was genuinely missing is the **accessibility statement**. This PR adds it, plus a small hardening of the existing gate.

## Changes

- **`docs/ACCESSIBILITY.md`** — the WCAG 2.1 AA conformance statement: current status (with the audited-routes table), how it's tested (and that `a11y.yml` enforces it in CI), the in-code measures already present (`lang="en"`, semantic controls, `:focus-visible`, contrast-aware theming), known limitations (manual screen-reader verification, map/canvas views), and how to report issues.
- **`tests/a11y/axe.spec.ts`** — tighten the gate to also fail on **`moderate`** impact (previously only critical/serious). Verified clean at all levels today, so this is a no-op now but catches a future moderate regression — and it's enforced by the existing `a11y.yml`.
- **`package.json`** — add a `test:a11y` script as a local convenience for the config CI already uses.

## Verification

```
npm run test:a11y  ->  5 passed
```

All claims here were checked against the running app (axe full-severity scan returned `[]` on `/`).

> Out of scope: a pre-existing SSR hydration mismatch in `FleetGrid` (`asset.uptime` differs server vs client) surfaces in the dev log; it's unrelated to accessibility and left untouched.

Closes #176
